### PR TITLE
バージョンを1.6.2に更新し、exportsを追加

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,8 @@
+{
+  "loader": "ts-node/esm",
+  "spec": "test/**/*.ts",
+  "timeout": 10000,
+  "recursive": true,
+  "extensions": ["ts"],
+  "require": ["ts-node/register"]
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,8 @@
-const js = require('@eslint/js');
-const tseslint = require('@typescript-eslint/eslint-plugin');
-const tsparser = require('@typescript-eslint/parser');
+import js from '@eslint/js';
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsparser from '@typescript-eslint/parser';
 
-module.exports = [
+export default [
   js.configs.recommended,
   {
     files: ['**/*.js'],

--- a/example/example.ts
+++ b/example/example.ts
@@ -1,7 +1,7 @@
-import ContentBasedRecommender from '../src/lib/ContentBasedRecommender';
-import { Document } from '../src/types';
-import posts from '../fixtures/sample-documents';
-import tags from '../fixtures/sample-document-tags';
+import ContentBasedRecommender from '../src/lib/ContentBasedRecommender.js';
+import { Document } from '../src/types/index.js';
+import posts from '../fixtures/sample-documents.js';
+import tags from '../fixtures/sample-document-tags.js';
 
 /**
  * Content-Based Recommenderの使用例

--- a/fixtures/sample-document-tags.ts
+++ b/fixtures/sample-document-tags.ts
@@ -1,4 +1,4 @@
-import { Document } from '../src/types';
+import { Document } from '../src/types/index.js';
 
 /**
  * サンプル文書タグデータ

--- a/fixtures/sample-documents.ts
+++ b/fixtures/sample-documents.ts
@@ -1,4 +1,4 @@
-import { Document } from '../src/types';
+import { Document } from '../src/types/index.js';
 
 /**
  * サンプル文書データ

--- a/fixtures/sample-japanese-documents.ts
+++ b/fixtures/sample-japanese-documents.ts
@@ -1,4 +1,4 @@
-import { Document } from '../src/types';
+import { Document } from '../src/types/index.js';
 
 /**
  * サンプル日本語文書データ

--- a/fixtures/sample-target-documents.ts
+++ b/fixtures/sample-target-documents.ts
@@ -1,4 +1,4 @@
-import { Document } from '../src/types';
+import { Document } from '../src/types/index.js';
 
 /**
  * サンプルターゲット文書データ

--- a/index.ts
+++ b/index.ts
@@ -2,5 +2,5 @@
  * Content-Based Recommender メインエントリーポイント
  * コンテンツベース推薦システムのメインクラスをエクスポート
  */
-export { default } from './src/lib/ContentBasedRecommender';
-export * from './src/types';
+export { default } from './src/lib/ContentBasedRecommender.js';
+export * from './src/types/index.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-content-based-recommender",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-content-based-recommender",
-      "version": "1.6.0",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "@types/kuromoji": "^0.1.3",
@@ -27,6 +27,7 @@
         "@typescript-eslint/eslint-plugin": "^8.35.0",
         "@typescript-eslint/parser": "^8.35.0",
         "chai": "^4.5.0",
+        "cross-env": "^7.0.3",
         "eslint": "^8.57.1",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.32.0",
@@ -1369,6 +1370,25 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,24 @@
 {
   "name": "ts-content-based-recommender",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A TypeScript-based content-based recommender with multilingual support (Japanese & English). Forked from content-based-recommender.",
+  "type": "commonjs",
   "homepage": "https://github.com/kensakurai/ts-content-based-recommender",
   "repository": {
     "type": "git",
     "url": "git://github.com/kensakurai/ts-content-based-recommender.git"
   },
   "main": "dist/index.js",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ts-content-based-recommender",
   "version": "1.6.2",
   "description": "A TypeScript-based content-based recommender with multilingual support (Japanese & English). Forked from content-based-recommender.",
-  "type": "commonjs",
+  "type": "module",
   "homepage": "https://github.com/kensakurai/ts-content-based-recommender",
   "repository": {
     "type": "git",
@@ -25,9 +25,10 @@
     "lint": "npx tsc --noEmit && eslint 'src/**/*.ts' 'test/**/*.ts'",
     "lint:fix": "eslint 'src/**/*.ts' 'test/**/*.ts' --fix",
     "tsc": "tsc --noEmit",
-    "test": "./node_modules/.bin/mocha --require ts-node/register 'test/**/*.ts'",
-    "example": "npx ts-node example/example.ts",
-    "dev": "npx ts-node"
+    "test": "npm run build && mocha dist/test/**/*.js",
+    "test:ts": "cross-env NODE_OPTIONS='--loader=ts-node/esm' mocha test/**/*.ts",
+    "example": "node --loader ts-node/esm example/example.ts",
+    "dev": "node --loader ts-node/esm"
   },
   "keywords": [
     "content-based",
@@ -87,12 +88,19 @@
     "@typescript-eslint/eslint-plugin": "^8.35.0",
     "@typescript-eslint/parser": "^8.35.0",
     "chai": "^4.5.0",
+    "cross-env": "^7.0.3",
     "eslint": "^8.57.1",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.32.0",
     "mocha": "^11.7.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
+  },
+  "ts-node": {
+    "esm": true,
+    "experimentalSpecifierResolution": "node",
+    "transpileOnly": true,
+    "files": true
   },
   "peerDependencies": {
     "typescript": ">=4.5.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,5 @@
  * Content-Based Recommender メインエントリーポイント
  * コンテンツベース推薦システムのメインクラスをエクスポート
  */
-export { default } from './lib/ContentBasedRecommender';
-export * from './types';
+export { default } from './lib/ContentBasedRecommender.js';
+export * from './types/index.js';

--- a/src/lib/ContentBasedRecommender.ts
+++ b/src/lib/ContentBasedRecommender.ts
@@ -7,13 +7,14 @@ import {
   ExportedModel,
   ProcessedDocument,
   ProcessingPipeline,
-} from '../types';
-import { ProcessingPipelineFactory } from './factories/ProcessingPipelineFactory';
-import { JapaneseTokenizer } from './tokenizers/JapaneseTokenizer';
-import { EnglishTokenFilter } from './filters/EnglishTokenFilter';
-import { JapaneseTokenFilter } from './filters/JapaneseTokenFilter';
+} from '../types/index.js';
+import { ProcessingPipelineFactory } from './factories/ProcessingPipelineFactory.js';
+import { JapaneseTokenizer } from './tokenizers/JapaneseTokenizer.js';
+import { EnglishTokenFilter } from './filters/EnglishTokenFilter.js';
+import { JapaneseTokenFilter } from './filters/JapaneseTokenFilter.js';
+import natural from 'natural';
 
-const { TfIdf } = require('natural');
+const { TfIdf } = natural;
 
 /**
  * デフォルト設定オプション
@@ -259,7 +260,7 @@ class ContentBasedRecommender {
       // 日本語の場合、品詞情報を含む詳細トークンを取得してフィルタリング
       const japaneseTokenizer = this.pipeline.tokenizer as JapaneseTokenizer;
       const japaneseFilter = this.pipeline.filter as JapaneseTokenFilter;
-      const detailedTokens = await japaneseTokenizer.getDetailedTokens(string);
+      const detailedTokens = await japaneseTokenizer.getDetailedJapaneseTokens(string);
       return japaneseFilter.filterWithPos(detailedTokens);
     } else if (this.options.language === 'en') {
       // 英語の場合、N-gram対応フィルタリング

--- a/src/lib/factories/ProcessingPipelineFactory.ts
+++ b/src/lib/factories/ProcessingPipelineFactory.ts
@@ -1,8 +1,8 @@
-import { ProcessingPipeline, TokenFilterOptions, ITokenizer } from '../../types';
-import { EnglishTokenizer } from '../tokenizers/EnglishTokenizer';
-import { JapaneseTokenizer } from '../tokenizers/JapaneseTokenizer';
-import { EnglishTokenFilter } from '../filters/EnglishTokenFilter';
-import { JapaneseTokenFilter } from '../filters/JapaneseTokenFilter';
+import { ProcessingPipeline, TokenFilterOptions, ITokenizer } from '../../types/index.js';
+import { EnglishTokenizer } from '../tokenizers/EnglishTokenizer.js';
+import { JapaneseTokenizer } from '../tokenizers/JapaneseTokenizer.js';
+import { EnglishTokenFilter } from '../filters/EnglishTokenFilter.js';
+import { JapaneseTokenFilter } from '../filters/JapaneseTokenFilter.js';
 
 /**
  * 処理パイプラインファクトリークラス

--- a/src/lib/filters/EnglishTokenFilter.ts
+++ b/src/lib/filters/EnglishTokenFilter.ts
@@ -1,5 +1,5 @@
 import * as sw from 'stopword';
-import { IEnglishTokenFilter, TokenFilterOptions } from '../../types';
+import { IEnglishTokenFilter, TokenFilterOptions } from '../../types/index.js';
 
 /**
  * 英語専用トークンフィルタークラス

--- a/src/lib/filters/JapaneseTokenFilter.ts
+++ b/src/lib/filters/JapaneseTokenFilter.ts
@@ -1,4 +1,4 @@
-import { IJapaneseTokenFilter, TokenFilterOptions, DetailedJapaneseToken } from '../../types';
+import { IJapaneseTokenFilter, TokenFilterOptions, DetailedJapaneseToken } from '../../types/index.js';
 
 /**
  * 日本語専用トークンフィルタークラス

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,13 +1,13 @@
 // トークナイザーのエクスポート
-export { EnglishTokenizer } from './tokenizers/EnglishTokenizer';
-export { JapaneseTokenizer } from './tokenizers/JapaneseTokenizer';
+export { EnglishTokenizer } from './tokenizers/EnglishTokenizer.js';
+export { JapaneseTokenizer } from './tokenizers/JapaneseTokenizer.js';
 
 // フィルターのエクスポート
-export { EnglishTokenFilter } from './filters/EnglishTokenFilter';
-export { JapaneseTokenFilter } from './filters/JapaneseTokenFilter';
+export { EnglishTokenFilter } from './filters/EnglishTokenFilter.js';
+export { JapaneseTokenFilter } from './filters/JapaneseTokenFilter.js';
 
 // ファクトリーのエクスポート
-export { ProcessingPipelineFactory } from './factories/ProcessingPipelineFactory';
+export { ProcessingPipelineFactory } from './factories/ProcessingPipelineFactory.js';
 
 // メインクラス
-export { default as ContentBasedRecommender } from './ContentBasedRecommender';
+export { default as ContentBasedRecommender } from './ContentBasedRecommender.js';

--- a/src/lib/tokenizers/EnglishTokenizer.ts
+++ b/src/lib/tokenizers/EnglishTokenizer.ts
@@ -1,9 +1,9 @@
-import * as natural from 'natural';
+import natural from 'natural';
 import striptags from 'striptags';
-import { ITokenizer } from '../../types';
+import { ITokenizer } from '../../types/index.js';
 
-const { PorterStemmer, NGrams } = natural;
-const tokenizer = new natural.WordTokenizer();
+const { PorterStemmer, NGrams, WordTokenizer } = natural;
+const tokenizer = new WordTokenizer();
 
 /**
  * 英語テキスト用のトークナイザークラス

--- a/src/lib/tokenizers/JapaneseTokenizer.ts
+++ b/src/lib/tokenizers/JapaneseTokenizer.ts
@@ -1,6 +1,6 @@
-import * as kuromoji from 'kuromoji';
+import kuromoji from 'kuromoji';
 import striptags from 'striptags';
-import { ITokenizer } from '../../types';
+import { ITokenizer, DetailedJapaneseToken } from '../../types/index.js';
 
 /**
  * 日本語テキスト用のトークナイザークラス
@@ -88,5 +88,20 @@ export class JapaneseTokenizer implements ITokenizer {
 
     // 形態素解析を実行
     return this.kuromojiTokenizer.tokenize(cleanText);
+  }
+
+  /**
+   * 詳細な形態素解析結果を取得する（DetailedJapaneseToken形式）
+   * @param text 解析対象のテキスト
+   * @returns DetailedJapaneseToken形式の解析結果のPromise
+   */
+  public async getDetailedJapaneseTokens(text: string): Promise<DetailedJapaneseToken[]> {
+    const kuromojiTokens = await this.getDetailedTokens(text);
+
+    return kuromojiTokens.map((token) => ({
+      pos: token.pos,
+      surface_form: token.surface_form,
+      basic_form: token.basic_form,
+    }));
   }
 }

--- a/test/ContentBasedRecommender.ts
+++ b/test/ContentBasedRecommender.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
-import ContentBasedRecommender from '../src/lib/ContentBasedRecommender';
-import { Document } from '../src/types';
-import sampleDocuments from '../fixtures/sample-documents';
-import sampleTargetDocuments from '../fixtures/sample-target-documents';
-import sampleJapaneseDocuments from '../fixtures/sample-japanese-documents';
+import ContentBasedRecommender from '../src/lib/ContentBasedRecommender.js';
+import { Document } from '../src/types/index.js';
+import sampleDocuments from '../fixtures/sample-documents.js';
+import sampleTargetDocuments from '../fixtures/sample-target-documents.js';
+import sampleJapaneseDocuments from '../fixtures/sample-japanese-documents.js';
 
 /**
  * ContentBasedRecommenderのテストスイート

--- a/test/ContentBasedRecommenderImproved.ts
+++ b/test/ContentBasedRecommenderImproved.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
-import ContentBasedRecommender from '../src/lib/ContentBasedRecommender';
-import { Document, TokenFilterOptions } from '../src/types';
+import ContentBasedRecommender from '../src/lib/ContentBasedRecommender.js';
+import { Document, TokenFilterOptions } from '../src/types/index.js';
 
 describe('ContentBasedRecommender - 改良版', () => {
   let recommender: ContentBasedRecommender;

--- a/test/factories/ProcessingPipelineFactory.ts
+++ b/test/factories/ProcessingPipelineFactory.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
-import { ProcessingPipelineFactory } from '../../src/lib/factories/ProcessingPipelineFactory';
-import { EnglishTokenizer } from '../../src/lib/tokenizers/EnglishTokenizer';
-import { JapaneseTokenizer } from '../../src/lib/tokenizers/JapaneseTokenizer';
-import { EnglishTokenFilter } from '../../src/lib/filters/EnglishTokenFilter';
-import { JapaneseTokenFilter } from '../../src/lib/filters/JapaneseTokenFilter';
+import { ProcessingPipelineFactory } from '../../src/lib/factories/ProcessingPipelineFactory.js';
+import { EnglishTokenizer } from '../../src/lib/tokenizers/EnglishTokenizer.js';
+import { JapaneseTokenizer } from '../../src/lib/tokenizers/JapaneseTokenizer.js';
+import { EnglishTokenFilter } from '../../src/lib/filters/EnglishTokenFilter.js';
+import { JapaneseTokenFilter } from '../../src/lib/filters/JapaneseTokenFilter.js';
 
 describe('ProcessingPipelineFactory', () => {
   describe('createPipeline', () => {

--- a/test/filters/EnglishTokenFilter.ts
+++ b/test/filters/EnglishTokenFilter.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { EnglishTokenFilter } from '../../src/lib/filters/EnglishTokenFilter';
+import { EnglishTokenFilter } from '../../src/lib/filters/EnglishTokenFilter.js';
 
 describe('EnglishTokenFilter', () => {
   let filter: EnglishTokenFilter;

--- a/test/filters/JapaneseTokenFilter.ts
+++ b/test/filters/JapaneseTokenFilter.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
-import { JapaneseTokenFilter } from '../../src/lib/filters/JapaneseTokenFilter';
-import { DetailedJapaneseToken } from '../../src/types';
+import { JapaneseTokenFilter } from '../../src/lib/filters/JapaneseTokenFilter.js';
+import { DetailedJapaneseToken } from '../../src/types/index.js';
 
 describe('JapaneseTokenFilter', () => {
   let filter: JapaneseTokenFilter;

--- a/test/index.ts
+++ b/test/index.ts
@@ -2,15 +2,15 @@
 // Mochaが自動的に実行するためのエントリポイント
 
 // 個別コンポーネントのテスト
-import './tokenizers/EnglishTokenizer';
-import './tokenizers/JapaneseTokenizer';
-import './filters/EnglishTokenFilter';
-import './filters/JapaneseTokenFilter';
-import './factories/ProcessingPipelineFactory';
+import './tokenizers/EnglishTokenizer.js';
+import './tokenizers/JapaneseTokenizer.js';
+import './filters/EnglishTokenFilter.js';
+import './filters/JapaneseTokenFilter.js';
+import './factories/ProcessingPipelineFactory.js';
 
 // 統合テスト
-import './ContentBasedRecommenderImproved';
-import './pipeline-integration-test';
+import './ContentBasedRecommenderImproved.js';
+import './pipeline-integration-test.js';
 
 // 既存のテスト（後方互換性）
-import './ContentBasedRecommender';
+import './ContentBasedRecommender.js';

--- a/test/pipeline-integration-test.ts
+++ b/test/pipeline-integration-test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import ContentBasedRecommender from '../src/lib/ContentBasedRecommender';
+import ContentBasedRecommender from '../src/lib/ContentBasedRecommender.js';
 
 describe('Pipeline Integration Tests', () => {
   describe('ContentBasedRecommender Integration Tests', () => {

--- a/test/tokenizers/EnglishTokenizer.ts
+++ b/test/tokenizers/EnglishTokenizer.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { EnglishTokenizer } from '../../src/lib/tokenizers/EnglishTokenizer';
+import { EnglishTokenizer } from '../../src/lib/tokenizers/EnglishTokenizer.js';
 
 describe('EnglishTokenizer', () => {
   let tokenizer: EnglishTokenizer;

--- a/test/tokenizers/JapaneseTokenizer.ts
+++ b/test/tokenizers/JapaneseTokenizer.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { JapaneseTokenizer } from '../../src/lib/tokenizers/JapaneseTokenizer';
+import { JapaneseTokenizer } from '../../src/lib/tokenizers/JapaneseTokenizer.js';
 
 describe('JapaneseTokenizer', () => {
   let tokenizer: JapaneseTokenizer;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,14 +25,15 @@
     "strictPropertyInitialization": false
   },
   "include": [
-    "src/**/*",
-    "test/**/*",
-    "example/**/*",
-    "fixtures/**/*"
+    "index.ts",
+    "src/**/*"
   ],
   "exclude": [
     "node_modules",
     "dist",
+    "test/**/*",
+    "example/**/*",
+    "fixtures/**/*",
     "**/*.test.ts",
     "**/*.spec.ts"
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
+    "module": "ESNext",
     "lib": ["ES2020", "DOM"],
     "outDir": "./dist",
     "rootDir": ".",
@@ -26,12 +26,12 @@
   },
   "include": [
     "index.ts",
-    "src/**/*"
+    "src/**/*",
+    "test/**/*"
   ],
   "exclude": [
     "node_modules",
     "dist",
-    "test/**/*",
     "example/**/*",
     "fixtures/**/*",
     "**/*.test.ts",

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
+  },
+  "include": [
+    "test/**/*",
+    "example/**/*"
+  ],
+  "ts-node": {
+    "esm": true,
+    "experimentalSpecifierResolution": "node"
+  }
+}


### PR DESCRIPTION
バージョンを1.6.2に更新し、CommonJSモジュールのエクスポートを追加しました。これにより、他のモジュールからのインポートが容易になります。また、不要なファイルを除外し、インクルード設定を整理しました。