### PR TITLE
feat: implement LSA(SVD) recommender for issue #19

### DIFF
--- a/benchmark/lsa-comparison.ts
+++ b/benchmark/lsa-comparison.ts
@@ -1,0 +1,298 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import ContentBasedRecommender from '../src/lib/ContentBasedRecommender.js';
+import { Document, RecommenderAlgorithm } from '../src/types/index.js';
+import evaluationEnDocuments from '../fixtures/evaluation-en-documents.js';
+import evaluationJaMixedDocuments from '../fixtures/evaluation-ja-mixed-documents.js';
+
+interface EvaluationDocument extends Document {
+  category: string;
+  tags: string[];
+}
+
+interface AccuracyMetrics {
+  precisionAt5: number;
+  recallAt5: number;
+  averageTagOverlapAt5: number;
+}
+
+interface WarmInferenceMetrics {
+  averageMs: number;
+  p95Ms: number;
+}
+
+interface BenchmarkResult extends AccuracyMetrics {
+  dataset: string;
+  algorithm: RecommenderAlgorithm;
+  documents: number;
+  trainMs: number;
+  warmInferenceAverageMs: number;
+  warmInferenceP95Ms: number;
+  rssMb: number;
+  rssDeltaMb: number;
+}
+
+const TOP_K = 5;
+const LSA_DIMENSIONS = 12;
+const WARM_INFERENCE_ITERATIONS = 500;
+const execFileAsync = promisify(execFile);
+const datasets = {
+  'evaluation-en': {
+    name: 'evaluation-en',
+    language: 'en' as const,
+    documents: evaluationEnDocuments as EvaluationDocument[],
+  },
+  'evaluation-ja-mixed': {
+    name: 'evaluation-ja-mixed',
+    language: 'ja' as const,
+    documents: evaluationJaMixedDocuments as EvaluationDocument[],
+  },
+};
+
+/**
+ * ミリ秒を丸める
+ * @param value 対象値
+ * @returns 小数第3位までに丸めた値
+ */
+function roundMetric(value: number): number {
+  return Number(value.toFixed(3));
+}
+
+/**
+ * ミリ秒を高精度で丸める
+ * @param value 対象値
+ * @returns 小数第6位までに丸めた値
+ */
+function roundFineMetric(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+/**
+ * 高精度な現在時刻をミリ秒で取得する
+ * @returns 現在時刻のミリ秒
+ */
+function nowMs(): number {
+  return Number(process.hrtime.bigint()) / 1_000_000;
+}
+
+/**
+ * 関連文書を取得する
+ * @param sourceDocument 基準文書
+ * @param documents 対象文書配列
+ * @returns 関連文書配列
+ */
+function getRelevantDocuments(sourceDocument: EvaluationDocument, documents: EvaluationDocument[]): EvaluationDocument[] {
+  return documents.filter((document) => document.id !== sourceDocument.id && document.category === sourceDocument.category);
+}
+
+/**
+ * タグの重なり率を計算する
+ * @param sourceDocument 基準文書
+ * @param recommendedDocument 推薦文書
+ * @returns タグ重なり率
+ */
+function getTagOverlapRatio(sourceDocument: EvaluationDocument, recommendedDocument: EvaluationDocument): number {
+  const sourceTags = new Set(sourceDocument.tags);
+  const recommendedTags = new Set(recommendedDocument.tags);
+  const union = new Set([...sourceTags, ...recommendedTags]);
+  const intersectionCount = Array.from(sourceTags).filter((tag) => recommendedTags.has(tag)).length;
+
+  if (union.size === 0) {
+    return 0;
+  }
+
+  return intersectionCount / union.size;
+}
+
+/**
+ * 推薦精度を評価する
+ * @param recommender 推薦器
+ * @param documents 評価文書配列
+ * @returns 精度指標
+ */
+function evaluateAccuracy(
+  recommender: ContentBasedRecommender,
+  documents: EvaluationDocument[]
+): AccuracyMetrics {
+  const documentMap = new Map(documents.map((document) => [document.id, document]));
+
+  const totals = documents.reduce((acc, sourceDocument) => {
+    const recommendations = recommender.getSimilarDocuments(sourceDocument.id, 0, TOP_K);
+    const relevantDocuments = getRelevantDocuments(sourceDocument, documents);
+    const recommendedDocuments = recommendations
+      .map((recommendation) => documentMap.get(recommendation.id))
+      .filter((document): document is EvaluationDocument => document !== undefined);
+    const relevantRecommendationCount = recommendedDocuments
+      .filter((document) => document.category === sourceDocument.category)
+      .length;
+    const tagOverlap = recommendedDocuments.reduce((overlapAcc, recommendedDocument) => (
+      overlapAcc + getTagOverlapRatio(sourceDocument, recommendedDocument)
+    ), 0);
+
+    acc.precision += relevantRecommendationCount / TOP_K;
+    acc.recall += relevantDocuments.length === 0 ? 0 : relevantRecommendationCount / relevantDocuments.length;
+    acc.tagOverlap += recommendedDocuments.length === 0 ? 0 : tagOverlap / recommendedDocuments.length;
+
+    return acc;
+  }, {
+    precision: 0,
+    recall: 0,
+    tagOverlap: 0,
+  });
+
+  return {
+    precisionAt5: roundMetric(totals.precision / documents.length),
+    recallAt5: roundMetric(totals.recall / documents.length),
+    averageTagOverlapAt5: roundMetric(totals.tagOverlap / documents.length),
+  };
+}
+
+/**
+ * ウォーム状態での推薦取得時間を計測する
+ * @param recommender 推薦器
+ * @param documents 評価文書配列
+ * @returns 推論指標
+ */
+function evaluateWarmInference(
+  recommender: ContentBasedRecommender,
+  documents: EvaluationDocument[]
+): WarmInferenceMetrics {
+  const durations = documents.map((document) => {
+    const start = nowMs();
+    for (let index = 0; index < WARM_INFERENCE_ITERATIONS; index += 1) {
+      recommender.getSimilarDocuments(document.id, 0, TOP_K);
+    }
+    return (nowMs() - start) / WARM_INFERENCE_ITERATIONS;
+  }).sort((left, right) => left - right);
+  const p95Index = Math.min(durations.length - 1, Math.ceil(durations.length * 0.95) - 1);
+  const totalDuration = durations.reduce((acc, duration) => acc + duration, 0);
+
+  return {
+    averageMs: roundFineMetric(totalDuration / durations.length),
+    p95Ms: roundFineMetric(durations[p95Index]),
+  };
+}
+
+/**
+ * 単一シナリオを計測する
+ * @param datasetName データセット名
+ * @param algorithm 推薦アルゴリズム
+ * @returns ベンチ結果
+ */
+async function benchmarkScenario(datasetName: keyof typeof datasets, algorithm: RecommenderAlgorithm): Promise<BenchmarkResult> {
+  const dataset = datasets[datasetName];
+  const { documents, language } = dataset;
+  const beforeRss = process.memoryUsage().rss;
+  const recommender = new ContentBasedRecommender({
+    algorithm,
+    language,
+    lsaDimensions: LSA_DIMENSIONS,
+    maxSimilarDocuments: TOP_K,
+    minScore: 0,
+  });
+
+  const trainingStart = nowMs();
+  await recommender.train(documents);
+  const trainMs = nowMs() - trainingStart;
+  const afterRss = process.memoryUsage().rss;
+
+  const accuracy = evaluateAccuracy(recommender, documents);
+  const warmInference = evaluateWarmInference(recommender, documents);
+
+  return {
+    dataset: datasetName,
+    algorithm,
+    documents: documents.length,
+    trainMs: roundMetric(trainMs),
+    warmInferenceAverageMs: warmInference.averageMs,
+    warmInferenceP95Ms: warmInference.p95Ms,
+    rssMb: roundMetric(afterRss / (1024 * 1024)),
+    rssDeltaMb: roundMetric((afterRss - beforeRss) / (1024 * 1024)),
+    precisionAt5: accuracy.precisionAt5,
+    recallAt5: accuracy.recallAt5,
+    averageTagOverlapAt5: accuracy.averageTagOverlapAt5,
+  };
+}
+
+/**
+ * CLIオプションの値を取得する
+ * @param flag オプション名
+ * @returns オプション値
+ */
+function getCliOption(flag: string): string | undefined {
+  const optionIndex = process.argv.indexOf(flag);
+  if (optionIndex === -1) {
+    return undefined;
+  }
+
+  return process.argv[optionIndex + 1];
+}
+
+/**
+ * 全シナリオのベンチマークを実行する
+ * @returns Promise<void>
+ */
+async function runAllBenchmarks(): Promise<void> {
+  const scenarios: Array<{ dataset: keyof typeof datasets; algorithm: RecommenderAlgorithm }> = [
+    { dataset: 'evaluation-en', algorithm: 'tfidf' },
+    { dataset: 'evaluation-en', algorithm: 'lsa' },
+    { dataset: 'evaluation-ja-mixed', algorithm: 'tfidf' },
+    { dataset: 'evaluation-ja-mixed', algorithm: 'lsa' },
+  ];
+  const results: BenchmarkResult[] = [];
+
+  for (const scenario of scenarios) {
+    const { stdout } = await execFileAsync(process.execPath, [
+      '--loader',
+      'ts-node/esm',
+      'benchmark/lsa-comparison.ts',
+      '--dataset',
+      scenario.dataset,
+      '--algorithm',
+      scenario.algorithm,
+    ], {
+      cwd: process.cwd(),
+      maxBuffer: 1024 * 1024,
+    });
+    const lines = stdout.trim().split('\n');
+    const jsonLine = lines[lines.length - 1];
+    results.push(JSON.parse(jsonLine) as BenchmarkResult);
+  }
+
+  console.log('LSA benchmark results');
+  console.table(results.map((result) => ({
+    dataset: result.dataset,
+    algorithm: result.algorithm,
+    documents: result.documents,
+    trainMs: result.trainMs,
+    warmInferenceAverageMs: result.warmInferenceAverageMs,
+    warmInferenceP95Ms: result.warmInferenceP95Ms,
+    rssMb: result.rssMb,
+    rssDeltaMb: result.rssDeltaMb,
+    precisionAt5: result.precisionAt5,
+    recallAt5: result.recallAt5,
+    averageTagOverlapAt5: result.averageTagOverlapAt5,
+  })));
+}
+
+/**
+ * ベンチマークを実行する
+ * @returns Promise<void>
+ */
+async function main(): Promise<void> {
+  const datasetName = getCliOption('--dataset') as keyof typeof datasets | undefined;
+  const algorithm = getCliOption('--algorithm') as RecommenderAlgorithm | undefined;
+
+  if (datasetName && algorithm) {
+    const result = await benchmarkScenario(datasetName, algorithm);
+    console.log(JSON.stringify(result));
+    return;
+  }
+
+  await runAllBenchmarks();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/fixtures/evaluation-en-documents.ts
+++ b/fixtures/evaluation-en-documents.ts
@@ -1,0 +1,156 @@
+import { Document } from '../src/types/index.js';
+
+/**
+ * 評価用の英語文書データ
+ * - language: 'en' での評価を想定（英語のみ）
+ * - 代理ラベルとして category/tags を持つ
+ */
+export interface EvaluationDocument extends Document {
+  /** 代理ラベル用カテゴリ */
+  category: string;
+  /** 代理ラベル用タグ */
+  tags: string[];
+  /** この文書セットの想定言語スコープ */
+  languageScope: 'en' | 'ja';
+}
+
+interface TopicTemplate {
+  category: string;
+  tags: string[];
+  contents: string[];
+}
+
+const enTopicTemplates: TopicTemplate[] = [
+  {
+    category: 'ai-fundamentals',
+    tags: ['ai', 'machine-learning', 'basics'],
+    contents: [
+      'AI fundamentals for product teams and practical planning',
+      'Understanding supervised learning with simple project examples',
+      'How to explain machine learning ideas to non technical stakeholders',
+      'A beginner guide to model evaluation and data split strategy',
+      'When to choose classification versus regression in real projects',
+      'Common pitfalls when starting an AI initiative in a startup'
+    ]
+  },
+  {
+    category: 'nlp',
+    tags: ['nlp', 'language-model', 'text-mining'],
+    contents: [
+      'Natural language processing basics for modern web services',
+      'Tokenization choices that improve text similarity quality',
+      'Named entity extraction for customer support automation',
+      'Practical sentiment analysis with lightweight model pipelines',
+      'How stemming and lemmatization affect retrieval relevance',
+      'Building a text normalization layer for noisy user input'
+    ]
+  },
+  {
+    category: 'web-frontend',
+    tags: ['frontend', 'react', 'performance'],
+    contents: [
+      'Frontend performance tuning with code splitting and lazy loading',
+      'State management patterns for large React applications',
+      'Accessibility checklist for production web interfaces',
+      'How to design reusable UI components with clear contracts',
+      'Monitoring user experience metrics in single page apps',
+      'Improving bundle size without sacrificing developer experience'
+    ]
+  },
+  {
+    category: 'web-backend',
+    tags: ['backend', 'nodejs', 'api'],
+    contents: [
+      'Node.js API design patterns for maintainable services',
+      'Structured error handling strategy for backend applications',
+      'Caching approaches for high traffic REST endpoints',
+      'Database transaction basics for consistent backend logic',
+      'Observability setup with logs metrics and distributed traces',
+      'Rate limiting and security controls for public APIs'
+    ]
+  },
+  {
+    category: 'data-engineering',
+    tags: ['data-pipeline', 'etl', 'analytics'],
+    contents: [
+      'Designing reliable ETL workflows for daily business reports',
+      'Schema evolution strategies in data warehouse projects',
+      'Data quality checks that prevent silent pipeline failures',
+      'Incremental processing patterns for large event streams',
+      'Partitioning techniques for faster analytical queries',
+      'How to document data contracts between producer and consumer teams'
+    ]
+  },
+  {
+    category: 'mobile-dev',
+    tags: ['mobile', 'ios', 'android'],
+    contents: [
+      'Mobile app architecture principles for long term maintainability',
+      'Battery and network optimization tips for mobile engineers',
+      'Offline first design patterns for travel and field apps',
+      'Push notification strategy that balances value and noise',
+      'Cross platform testing workflow for release confidence',
+      'App startup performance tuning on constrained devices'
+    ]
+  },
+  {
+    category: 'security',
+    tags: ['security', 'authentication', 'threat-modeling'],
+    contents: [
+      'Threat modeling workshop template for product engineering teams',
+      'Authentication and session management best practices',
+      'Secrets management patterns for cloud native applications',
+      'Security review checklist for third party integrations',
+      'How to handle vulnerability reports and coordinated disclosure',
+      'Defensive coding habits that reduce common attack surfaces'
+    ]
+  },
+  {
+    category: 'cloud-ops',
+    tags: ['cloud', 'kubernetes', 'sre'],
+    contents: [
+      'Service reliability engineering basics for small teams',
+      'Kubernetes deployment strategies with safe rollback plans',
+      'Capacity planning with realistic growth assumptions',
+      'Incident response process that improves learning after outages',
+      'Cost optimization tactics for multi environment cloud setups',
+      'SLO definition and alerting policy for customer facing services'
+    ]
+  },
+  {
+    category: 'product-management',
+    tags: ['product', 'roadmap', 'experimentation'],
+    contents: [
+      'How to prioritize roadmap items with clear value signals',
+      'Running product discovery interviews with actionable outcomes',
+      'Experiment design for measuring feature impact reliably',
+      'Balancing short term delivery and long term platform health',
+      'Writing product requirement documents that engineers can trust',
+      'Communication patterns between product design and engineering'
+    ]
+  },
+  {
+    category: 'fintech',
+    tags: ['fintech', 'payments', 'risk'],
+    contents: [
+      'Payments integration checklist for subscription products',
+      'Fraud detection signals for card not present transactions',
+      'Designing ledger systems with auditability and accuracy',
+      'Regulatory concerns in fintech product expansion',
+      'Risk scoring basics for digital lending services',
+      'Operational controls for handling chargeback disputes'
+    ]
+  }
+];
+
+const evaluationEnDocuments: EvaluationDocument[] = enTopicTemplates.flatMap((topic, topicIndex) => (
+  topic.contents.map((content, contentIndex) => ({
+    id: `en-eval-${String(topicIndex + 1).padStart(2, '0')}-${String(contentIndex + 1).padStart(2, '0')}`,
+    content,
+    category: topic.category,
+    tags: topic.tags,
+    languageScope: 'en'
+  }))
+));
+
+export default evaluationEnDocuments;

--- a/fixtures/evaluation-ja-mixed-documents.ts
+++ b/fixtures/evaluation-ja-mixed-documents.ts
@@ -1,0 +1,156 @@
+import { Document } from '../src/types/index.js';
+
+/**
+ * 評価用の日英混在文書データ
+ * - language: 'ja' での評価を想定（日英混在）
+ * - 代理ラベルとして category/tags を持つ
+ */
+export interface EvaluationMixedDocument extends Document {
+  /** 代理ラベル用カテゴリ */
+  category: string;
+  /** 代理ラベル用タグ */
+  tags: string[];
+  /** この文書セットの想定言語スコープ */
+  languageScope: 'en' | 'ja';
+}
+
+interface TopicTemplate {
+  category: string;
+  tags: string[];
+  contents: string[];
+}
+
+const jaMixedTopicTemplates: TopicTemplate[] = [
+  {
+    category: 'ai-fundamentals',
+    tags: ['ai', '人工知能', 'machine-learning'],
+    contents: [
+      'AI導入の最初の一歩と小さく始めるための設計ポイント',
+      'Machine learning project planning for small product teams',
+      '人工知能の基礎概念をプロダクトマネージャー向けに解説する',
+      'How to define success metrics for an AI feature release',
+      '教師あり学習と教師なし学習の違いを実務例で比較する',
+      'Evaluating model quality with practical baseline strategies'
+    ]
+  },
+  {
+    category: 'nlp',
+    tags: ['nlp', '自然言語処理', 'text-mining'],
+    contents: [
+      '自然言語処理におけるトークン化と前処理の実践',
+      'Text normalization techniques for multilingual user input',
+      '形態素解析とステミングの使い分けで精度を改善する',
+      'Entity extraction workflow for support ticket automation',
+      '日英混在テキストの類似度計算で起きる失敗パターン',
+      'Lightweight sentiment analysis for customer feedback loops'
+    ]
+  },
+  {
+    category: 'web-frontend',
+    tags: ['frontend', 'フロントエンド', 'react'],
+    contents: [
+      'Reactアプリの描画最適化と再レンダリング削減の基本',
+      'Frontend accessibility improvements for enterprise dashboards',
+      'デザインシステムを壊さないコンポーネント分割戦略',
+      'Performance budget planning for modern web interfaces',
+      'フロントエンド監視で見るべき主要なUXメトリクス',
+      'State management trade offs in large single page applications'
+    ]
+  },
+  {
+    category: 'web-backend',
+    tags: ['backend', 'バックエンド', 'nodejs'],
+    contents: [
+      'Node.jsバックエンドでのエラーハンドリング設計',
+      'API versioning strategy for long lived client integrations',
+      '分散トレーシングを使った障害切り分けの実践手順',
+      'Caching policy design for read heavy service endpoints',
+      'データ整合性を守るトランザクション設計の勘所',
+      'Rate limiting and abuse prevention for public APIs'
+    ]
+  },
+  {
+    category: 'data-engineering',
+    tags: ['data', 'データ基盤', 'etl'],
+    contents: [
+      'データ基盤におけるETLジョブの再実行戦略と冪等性',
+      'Incremental pipeline design for near real time analytics',
+      'スキーマ変更時に下流影響を最小化する運用方法',
+      'Data quality assertions to catch silent corruption early',
+      'イベントログのパーティション設計とクエリ最適化',
+      'Practical data contract templates between product teams'
+    ]
+  },
+  {
+    category: 'security',
+    tags: ['security', 'セキュリティ', 'auth'],
+    contents: [
+      'セキュリティレビューを開発プロセスに組み込む方法',
+      'Authentication hardening patterns for internal admin tools',
+      '秘密情報の管理とローテーションを自動化する設計',
+      'Threat modeling checklist for new feature launches',
+      '脆弱性報告を受けたときの初動と社内連携フロー',
+      'Defensive coding practices to reduce injection risks'
+    ]
+  },
+  {
+    category: 'cloud-ops',
+    tags: ['cloud', 'クラウド', 'sre'],
+    contents: [
+      'SREの基本とサービスレベル目標の決め方',
+      'Kubernetes rollout patterns with low risk migration',
+      '障害対応で学びを残すためのポストモーテム設計',
+      'Cloud cost controls for multi environment deployments',
+      'オンコール運用を持続可能にするアラート設計',
+      'Capacity planning approach for seasonal traffic spikes'
+    ]
+  },
+  {
+    category: 'mobile-dev',
+    tags: ['mobile', 'モバイル', 'ios'],
+    contents: [
+      'モバイルアプリの起動速度改善と初期描画最適化',
+      'Offline first sync design for field worker applications',
+      'iOSとAndroidで共通化しやすい画面設計の実例',
+      'Battery friendly networking for background sync tasks',
+      'クラッシュ分析から改善施策を優先順位付けする',
+      'Cross platform release testing with limited QA resources'
+    ]
+  },
+  {
+    category: 'product-management',
+    tags: ['product', 'プロダクト', 'roadmap'],
+    contents: [
+      'プロダクトロードマップを価値ベースで整理する方法',
+      'Discovery interview methods for ambiguous user needs',
+      '実験設計で避けるべき計測バイアスと判断ミス',
+      'How to align engineering and product on outcome goals',
+      '要求定義の粒度を揃えて開発速度を落とさない工夫',
+      'Roadmap communication patterns for executive stakeholders'
+    ]
+  },
+  {
+    category: 'fintech',
+    tags: ['fintech', '金融', 'payments'],
+    contents: [
+      '決済機能の導入時に確認すべき運用と障害対応設計',
+      'Fraud prevention signals for subscription payment systems',
+      '台帳設計で整合性と監査性を両立させる実践例',
+      'Regulatory checkpoints for launching fintech products',
+      '与信スコアリングの前処理と特徴量設計の基本',
+      'Chargeback handling workflow for international merchants'
+    ]
+  }
+];
+
+const evaluationJaMixedDocuments: EvaluationMixedDocument[] = jaMixedTopicTemplates.flatMap((topic, topicIndex) => (
+  topic.contents.map((content, contentIndex) => ({
+    id: `ja-eval-${String(topicIndex + 1).padStart(2, '0')}-${String(contentIndex + 1).padStart(2, '0')}`,
+    content,
+    category: topic.category,
+    tags: topic.tags,
+    languageScope: 'ja'
+  }))
+));
+
+export default evaluationJaMixedDocuments;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/kuromoji": "^0.1.3",
         "kuromoji": "^0.1.2",
+        "ml-matrix": "^6.12.1",
         "natural": "^8.1.0",
         "stopword": "^3.1.5",
         "striptags": "^3.2.0",
@@ -362,6 +363,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -494,6 +496,7 @@
       "integrity": "sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
@@ -570,6 +573,7 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -781,6 +785,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1790,6 +1795,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1926,6 +1932,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -2787,6 +2794,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/is-any-array": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-any-array/-/is-any-array-3.0.0.tgz",
+      "integrity": "sha512-o4h+tylWykC4BD1vaejp6gDxoM13bwW8FGuNs4yIKpj8xbBJcRxJx8vZpq0dCr7ZDEfeKjmsi/euolKhX6f/ww==",
+      "license": "MIT"
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -3507,6 +3520,45 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/ml-array-max": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-array-max/-/ml-array-max-2.0.0.tgz",
+      "integrity": "sha512-QQZ4kENwpWmyNb98UXRDFXrmtIXuXtt1+bSbda/2KA85+F+rrJP8hZk6QOkCQXM2Th9mUDYdq/PNByPdT9ID4A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^3.0.0"
+      }
+    },
+    "node_modules/ml-array-min": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-array-min/-/ml-array-min-2.0.0.tgz",
+      "integrity": "sha512-GRj6Ky6sW9vGL6yIjgsHmXZ9YgrdmcQ8nCxPqEGeKc6dkfYg1XDYxGFxADUjNuZyoCd5PUscWAS4N+cFaX6hFg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^3.0.0"
+      }
+    },
+    "node_modules/ml-array-rescale": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-array-rescale/-/ml-array-rescale-2.0.0.tgz",
+      "integrity": "sha512-2GGtKfSno94/kIloWGvpp/U5Q5vLvLrza+SAaGsLeo6Xj4mEbA6Gqx+oTfZFkxnd1grT2X007HfJNs3T5BsiVg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^3.0.0",
+        "ml-array-max": "^2.0.0",
+        "ml-array-min": "^2.0.0"
+      }
+    },
+    "node_modules/ml-matrix": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/ml-matrix/-/ml-matrix-6.12.2.tgz",
+      "integrity": "sha512-GC+BnW+pBh8Auap8goAxY0senAmF0IEoc3HNVSfnfbvGw0buuDIYb9kAKMS1l+GiwJ1rfK2bzJ8IHhwjzATSFA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-any-array": "^3.0.0",
+        "ml-array-rescale": "^2.0.0"
+      }
+    },
     "node_modules/mocha": {
       "version": "11.7.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
@@ -3985,6 +4037,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -5207,6 +5260,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "tsc": "tsc --noEmit",
     "test": "npm run build && mocha dist/test/**/*.js",
     "test:ts": "cross-env NODE_OPTIONS='--loader=ts-node/esm' mocha test/**/*.ts",
+    "benchmark:lsa": "node --loader ts-node/esm benchmark/lsa-comparison.ts",
     "example": "node --loader ts-node/esm example/example.ts",
     "dev": "node --loader ts-node/esm"
   },
@@ -72,6 +73,7 @@
   "dependencies": {
     "@types/kuromoji": "^0.1.3",
     "kuromoji": "^0.1.2",
+    "ml-matrix": "^6.12.1",
     "natural": "^8.1.0",
     "stopword": "^3.1.5",
     "striptags": "^3.2.0",

--- a/src/lib/ContentBasedRecommender.ts
+++ b/src/lib/ContentBasedRecommender.ts
@@ -1,5 +1,6 @@
 import * as _ from 'underscore';
 import Vector from 'vector-object';
+import { Matrix, SingularValueDecomposition } from 'ml-matrix';
 import {
   Document,
   RecommenderOptions,
@@ -24,7 +25,9 @@ const defaultOptions: RecommenderOptions = {
   maxSimilarDocuments: Number.MAX_SAFE_INTEGER,
   minScore: 0,
   debug: false,
+  algorithm: 'tfidf',
   language: 'en',
+  lsaDimensions: 12,
   tokenFilterOptions: {
     removeDuplicates: true,
     removeStopwords: true,
@@ -92,9 +95,19 @@ class ContentBasedRecommender {
       throw new Error('The option minScore should be a number between 0 and 1');
     }
 
+    if ((options.algorithm !== undefined) &&
+      (!_.isString(options.algorithm) || !['tfidf', 'lsa'].includes(options.algorithm))) {
+      throw new Error('The option algorithm should be either "tfidf" or "lsa"');
+    }
+
     if ((options.language !== undefined) &&
       (!_.isString(options.language) || !['en', 'ja'].includes(options.language))) {
       throw new Error('The option language should be either "en" or "ja"');
+    }
+
+    if ((options.lsaDimensions !== undefined) &&
+      (!Number.isInteger(options.lsaDimensions) || options.lsaDimensions <= 0)) {
+      throw new Error('The option lsaDimensions should be integer and greater than 0');
     }
 
     const prevLanguage = this.options?.language;
@@ -145,8 +158,11 @@ class ContentBasedRecommender {
     const preprocessTargetDocs = await this._preprocessDocuments(targetDocuments, this.options);
 
     // ステップ2 - 文書ベクトルの作成
-    const docVectors = this._produceWordVectors(preprocessDocs, this.options);
-    const targetDocVectors = this._produceWordVectors(preprocessTargetDocs, this.options);
+    const { documentVectors: docVectors, targetDocumentVectors: targetDocVectors } = this._produceBidirectionalWordVectors(
+      preprocessDocs,
+      preprocessTargetDocs,
+      this.options
+    );
 
     // ステップ3 - 類似度の計算
     this.data = this._calculateSimilaritiesBetweenTwoVectors(docVectors, targetDocVectors, this.options);
@@ -296,6 +312,49 @@ class ContentBasedRecommender {
    * @returns 文書ベクトル配列
    */
   private _produceWordVectors(processedDocuments: ProcessedDocument[], options: RecommenderOptions): DocumentVector[] {
+    if (options.algorithm === 'lsa') {
+      return this._produceLsaWordVectors(processedDocuments, options);
+    }
+
+    return this._produceTfIdfWordVectors(processedDocuments, options);
+  }
+
+  /**
+   * 双方向学習向けに文書ベクトルを生成する
+   * @param processedDocuments メイン文書配列
+   * @param targetProcessedDocuments ターゲット文書配列
+   * @param options 設定オプション
+   * @returns 生成済みベクトル
+   */
+  private _produceBidirectionalWordVectors(
+    processedDocuments: ProcessedDocument[],
+    targetProcessedDocuments: ProcessedDocument[],
+    options: RecommenderOptions
+  ): { documentVectors: DocumentVector[]; targetDocumentVectors: DocumentVector[] } {
+    if (options.algorithm !== 'lsa') {
+      return {
+        documentVectors: this._produceTfIdfWordVectors(processedDocuments, options),
+        targetDocumentVectors: this._produceTfIdfWordVectors(targetProcessedDocuments, options)
+      };
+    }
+
+    const allDocuments = processedDocuments.concat(targetProcessedDocuments);
+    const allVectors = this._produceLsaWordVectors(allDocuments, options);
+    const splitIndex = processedDocuments.length;
+
+    return {
+      documentVectors: allVectors.slice(0, splitIndex),
+      targetDocumentVectors: allVectors.slice(splitIndex)
+    };
+  }
+
+  /**
+   * TF-IDFベースの文書ベクトルを生成する
+   * @param processedDocuments 前処理済み文書配列
+   * @param options 設定オプション
+   * @returns 文書ベクトル配列
+   */
+  private _produceTfIdfWordVectors(processedDocuments: ProcessedDocument[], options: RecommenderOptions): DocumentVector[] {
     // TF-IDFの処理
     const tfidf = new TfIdf();
 
@@ -333,6 +392,111 @@ class ContentBasedRecommender {
   }
 
   /**
+   * LSAベースの文書ベクトルを生成する
+   * @param processedDocuments 前処理済み文書配列
+   * @param options 設定オプション
+   * @returns 文書ベクトル配列
+   */
+  private _produceLsaWordVectors(processedDocuments: ProcessedDocument[], options: RecommenderOptions): DocumentVector[] {
+    if (processedDocuments.length === 0) {
+      return [];
+    }
+
+    const { matrix } = this._buildTfIdfMatrix(processedDocuments);
+    if (matrix.columns === 0) {
+      return this._createZeroVectors(processedDocuments);
+    }
+
+    const shouldTranspose = matrix.columns > matrix.rows;
+    const matrixForSvd = shouldTranspose ? matrix.transpose() : matrix;
+    const svd = new SingularValueDecomposition(matrixForSvd, {
+      autoTranspose: false,
+    });
+    const singularValues = svd.diagonal;
+    if (singularValues.length === 0) {
+      return this._createZeroVectors(processedDocuments);
+    }
+
+    const latentDimensions = Math.min(options.lsaDimensions!, singularValues.length);
+    const documentBasis = shouldTranspose
+      ? svd.rightSingularVectors.subMatrix(0, processedDocuments.length - 1, 0, latentDimensions - 1)
+      : svd.leftSingularVectors.subMatrix(0, processedDocuments.length - 1, 0, latentDimensions - 1);
+    const truncatedDiagonal = Matrix.diag(singularValues.slice(0, latentDimensions));
+    const reducedMatrix = documentBasis.mmul(truncatedDiagonal);
+
+    return processedDocuments.map((processedDocument, index) => {
+      const hash: Record<string, number> = {};
+
+      for (let dimensionIndex = 0; dimensionIndex < latentDimensions; dimensionIndex += 1) {
+        hash[`dim_${dimensionIndex}`] = reducedMatrix.get(index, dimensionIndex);
+      }
+
+      return {
+        id: processedDocument.id,
+        vector: new Vector(hash),
+      };
+    });
+  }
+
+  /**
+   * LSA用のTF-IDF行列を構築する
+   * @param processedDocuments 前処理済み文書配列
+   * @returns TF-IDF行列
+   */
+  private _buildTfIdfMatrix(processedDocuments: ProcessedDocument[]): { matrix: Matrix; terms: string[] } {
+    const termSet = new Set<string>();
+    const termDocumentFrequency = new Map<string, number>();
+
+    processedDocuments.forEach((processedDocument) => {
+      const uniqueTerms = new Set(processedDocument.tokens);
+
+      processedDocument.tokens.forEach((token) => {
+        termSet.add(token);
+      });
+
+      uniqueTerms.forEach((term) => {
+        termDocumentFrequency.set(term, (termDocumentFrequency.get(term) ?? 0) + 1);
+      });
+    });
+
+    const terms = Array.from(termSet).sort();
+    const matrix = Matrix.zeros(processedDocuments.length, terms.length);
+    const totalDocuments = processedDocuments.length;
+
+    processedDocuments.forEach((processedDocument, rowIndex) => {
+      const termFrequency = processedDocument.tokens.reduce((acc: Record<string, number>, token) => {
+        acc[token] = (acc[token] ?? 0) + 1;
+        return acc;
+      }, {});
+
+      terms.forEach((term, columnIndex) => {
+        const tf = termFrequency[term] ?? 0;
+        if (tf === 0) {
+          return;
+        }
+
+        const documentFrequency = termDocumentFrequency.get(term) ?? 0;
+        const idf = Math.log((1 + totalDocuments) / (1 + documentFrequency)) + 1;
+        matrix.set(rowIndex, columnIndex, tf * idf);
+      });
+    });
+
+    return { matrix, terms };
+  }
+
+  /**
+   * ゼロベクトルの文書ベクトル配列を生成する
+   * @param processedDocuments 前処理済み文書配列
+   * @returns 文書ベクトル配列
+   */
+  private _createZeroVectors(processedDocuments: ProcessedDocument[]): DocumentVector[] {
+    return processedDocuments.map((processedDocument) => ({
+      id: processedDocument.id,
+      vector: new Vector({}),
+    }));
+  }
+
+  /**
    * 2つのベクトルセット間の類似度を計算する（双方向学習用）
    * @param documentVectors メイン文書のベクトル配列
    * @param targetDocumentVectors ターゲット文書のベクトル配列
@@ -360,7 +524,7 @@ class ContentBasedRecommender {
         const vi = documentVectorA.vector;
         const idj = targetDocumentVectorB.id;
         const vj = targetDocumentVectorB.vector;
-        const similarity = vi.getCosineSimilarity(vj);
+        const similarity = this._getCosineSimilarity(vi, vj);
 
         if (similarity > options.minScore!) {
           data[idi].push({
@@ -412,7 +576,7 @@ class ContentBasedRecommender {
         const documentVectorB = documentVectors[j];
         const idj = documentVectorB.id;
         const vj = documentVectorB.vector;
-        const similarity = vi.getCosineSimilarity(vj);
+        const similarity = this._getCosineSimilarity(vi, vj);
 
         if (similarity > options.minScore!) {
           data[idi].push({
@@ -431,6 +595,17 @@ class ContentBasedRecommender {
     this.orderDocuments(data, options);
 
     return data;
+  }
+
+  /**
+   * コサイン類似度を安全に取得する
+   * @param vectorA ベクトルA
+   * @param vectorB ベクトルB
+   * @returns コサイン類似度
+   */
+  private _getCosineSimilarity(vectorA: Vector, vectorB: Vector): number {
+    const similarity = vectorA.getCosineSimilarity(vectorB);
+    return Number.isFinite(similarity) ? similarity : 0;
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,11 @@ export interface Document {
 }
 
 /**
+ * 推薦アルゴリズムの種別
+ */
+export type RecommenderAlgorithm = 'tfidf' | 'lsa';
+
+/**
  * ContentBasedRecommenderの設定オプション
  */
 export interface RecommenderOptions {
@@ -26,8 +31,12 @@ export interface RecommenderOptions {
   minScore?: number;
   /** デバッグモードの有効化 */
   debug?: boolean;
+  /** 推薦アルゴリズム */
+  algorithm?: RecommenderAlgorithm;
   /** 使用する言語（デフォルト: 'en'、日本語: 'ja'） */
   language?: 'en' | 'ja';
+  /** LSAで利用する潜在次元数 */
+  lsaDimensions?: number;
   /** トークンフィルターのオプション */
   tokenFilterOptions?: TokenFilterOptions;
 }

--- a/test/ContentBasedRecommender.ts
+++ b/test/ContentBasedRecommender.ts
@@ -45,6 +45,24 @@ describe('ContentBasedRecommender', () => {
         recommender.train(sampleDocuments);
       }).to.throw('The option minScore should be a number between 0 and 1');
     });
+
+    it('should only accept algorithm as tfidf or lsa', () => {
+      expect(() => {
+        const recommender = new ContentBasedRecommender({
+          algorithm: 'bm25' as any,
+        });
+        recommender.train(sampleDocuments);
+      }).to.throw('The option algorithm should be either "tfidf" or "lsa"');
+    });
+
+    it('should only accept lsaDimensions greater than 0', () => {
+      expect(() => {
+        const recommender = new ContentBasedRecommender({
+          lsaDimensions: 0,
+        });
+        recommender.train(sampleDocuments);
+      }).to.throw('The option lsaDimensions should be integer and greater than 0');
+    });
   });
 
   describe('documents validation', () => {

--- a/test/LSARecommender.ts
+++ b/test/LSARecommender.ts
@@ -1,0 +1,95 @@
+import { expect } from 'chai';
+import ContentBasedRecommender from '../src/lib/ContentBasedRecommender.js';
+import { Document } from '../src/types/index.js';
+
+describe('LSARecommender', () => {
+  it('should train English documents with LSA and rank related content first', async () => {
+    const recommender = new ContentBasedRecommender({
+      algorithm: 'lsa',
+      language: 'en',
+      lsaDimensions: 2,
+      minScore: 0.01,
+    });
+
+    const documents: Document[] = [
+      { id: '1', content: 'javascript frontend component design patterns' },
+      { id: '2', content: 'javascript frontend tutorial for component design' },
+      { id: '3', content: 'quantum physics particle experiment results' },
+      { id: '4', content: 'web component architecture with javascript frontend' },
+    ];
+
+    await recommender.train(documents);
+
+    const similarDocuments = recommender.getSimilarDocuments('1');
+
+    expect(similarDocuments).to.have.length.greaterThan(0);
+    expect(similarDocuments[0].id).to.be.oneOf(['2', '4']);
+    expect(similarDocuments[0].score).to.be.a('number');
+  });
+
+  it('should respect maxSimilarDocuments with LSA', async () => {
+    const recommender = new ContentBasedRecommender({
+      algorithm: 'lsa',
+      language: 'en',
+      lsaDimensions: 2,
+      maxSimilarDocuments: 1,
+      minScore: 0.01,
+    });
+
+    const documents: Document[] = [
+      { id: '1', content: 'machine learning project planning and metrics' },
+      { id: '2', content: 'machine learning evaluation metrics and baselines' },
+      { id: '3', content: 'model deployment planning for machine learning teams' },
+    ];
+
+    await recommender.train(documents);
+
+    expect(recommender.getSimilarDocuments('1')).to.have.length.at.most(1);
+  });
+
+  it('should train mixed Japanese and English documents with LSA', async () => {
+    const recommender = new ContentBasedRecommender({
+      algorithm: 'lsa',
+      language: 'ja',
+      lsaDimensions: 2,
+      minScore: 0.01,
+    });
+
+    const documents: Document[] = [
+      { id: '1', content: '機械学習 machine learning の基礎を学ぶ' },
+      { id: '2', content: 'machine learning project planning とモデル評価' },
+      { id: '3', content: '旅行ガイドとホテル予約のコツ' },
+    ];
+
+    await recommender.train(documents);
+
+    const similarDocuments = recommender.getSimilarDocuments('1');
+    const similarIds = similarDocuments.map((document) => document.id);
+
+    expect(similarIds).to.include('2');
+  }).timeout(10000);
+
+  it('should support bidirectional training with LSA', async () => {
+    const recommender = new ContentBasedRecommender({
+      algorithm: 'lsa',
+      language: 'en',
+      lsaDimensions: 2,
+      minScore: 0.01,
+    });
+
+    const documents: Document[] = [
+      { id: 'post-1', content: 'javascript frontend component design system' },
+      { id: 'post-2', content: 'database indexing and query optimization guide' },
+    ];
+    const targetDocuments: Document[] = [
+      { id: 'tag-frontend', content: 'frontend javascript component ui' },
+      { id: 'tag-database', content: 'database query performance' },
+    ];
+
+    await recommender.trainBidirectional(documents, targetDocuments);
+
+    const similarDocuments = recommender.getSimilarDocuments('post-1');
+    expect(similarDocuments).to.have.length.greaterThan(0);
+    expect(similarDocuments[0].id).to.equal('tag-frontend');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
   },
   "include": [
     "index.ts",
+    "benchmark/**/*",
     "src/**/*",
     "test/**/*"
   ],


### PR DESCRIPTION
Closes #19

## Summary
- add opt-in LSA recommender support via `algorithm: 'lsa'` and `lsaDimensions`
- keep the current TF-IDF + cosine flow as the default behavior for backward compatibility
- implement SVD-based vectorization inside the recommender flow using `ml-matrix`
- add English and mixed Japanese/English evaluation fixtures for proxy-label benchmarking
- add LSA-focused tests and a standalone benchmark script for speed, accuracy, and memory comparison

## Main changes
- update `ContentBasedRecommender` to branch between TF-IDF and LSA vector generation
- extend public types with algorithm selection and LSA dimension options
- add `benchmark/lsa-comparison.ts` for local comparison across `en` and `ja`
- add `test/LSARecommender.ts` and extend option validation coverage

## Validation
- `npm run tsc`
- `npm run test`
- `node --loader ts-node/esm benchmark/lsa-comparison.ts`

## Benchmark results
Local run on macOS.

| dataset | algorithm | trainMs | warmInferenceAverageMs | warmInferenceP95Ms | rssMb | rssDeltaMb | precision@5 | recall@5 | averageTagOverlapAt5 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| evaluation-en | tfidf | 27.227 | 0.000022 | 0.000042 | 536.234 | 31.719 | 0.123 | 0.123 | 0.151 |
| evaluation-en | lsa | 103.320 | 0.000020 | 0.000044 | 600.203 | 94.359 | 0.120 | 0.120 | 0.120 |
| evaluation-ja-mixed | tfidf | 6209.162 | 0.000019 | 0.000040 | 5733.313 | 5220.016 | 0.050 | 0.050 | 0.050 |
| evaluation-ja-mixed | lsa | 5958.279 | 0.000019 | 0.000043 | 5798.422 | 5287.531 | 0.070 | 0.070 | 0.070 |

## Notes
- no existing public API was removed
- callers that do not specify `algorithm` continue to use the existing TF-IDF behavior
- the benchmark is intentionally separate from `test/` so CI test execution remains stable
