### PR TITLE
refactor: ContentBasedRecommender をサービス／ストラテジー／ファクトリーに分割

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This package is forked from [stanleyfok/content-based-recommender](https://githu
 * **Factory Pattern**: Introduced `ProcessingPipelineFactory` for easy component creation
 * **Enhanced Testing**: Moved all tests to `test/` directory with improved coverage
 * **Improved Japanese Support**: Advanced morphological analysis with part-of-speech filtering
+* **BM25 Support**: Added MiniSearch-based BM25 ranking with English and Japanese preprocessing
 * **Better TypeScript Support**: Comprehensive type definitions for all components
 
 #### 1.5.0
@@ -84,8 +85,8 @@ After the recommender is trained by an array of documents, it can tell the list 
 
 The training process involves 3 main steps:
 * content pre-processing, such as html tag stripping, [stopwords](http://xpo6.com/list-of-english-stop-words/) removal and [stemming](http://9ol.es/porter_js_demo.html)
-* document vectors formation using [tf-idf](https://lizrush.gitbooks.io/algorithms-for-webdevs-ebook/content/chapters/tf-idf.html)
-* find the [cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity) scores between all document vectors
+* ranking document features using [tf-idf](https://lizrush.gitbooks.io/algorithms-for-webdevs-ebook/content/chapters/tf-idf.html), LSA, or BM25
+* calculate related document scores from vectors or BM25 search results depending on the selected algorithm
 
 Special thanks to the library [natural](https://www.npmjs.com/package/natural) helps a lot by providing a lot of NLP functionalities, such as tf-idf and word stemming.
 
@@ -149,6 +150,47 @@ console.log(similarDocuments);
   ]
 */
 ```
+
+### BM25 ranking
+
+Use `algorithm: 'bm25'` when you want keyword-heavy ranking with MiniSearch.
+If a document includes `title`, BM25 indexes both `title` and `content`.
+Japanese documents are tokenized with the existing kuromoji pipeline before indexing.
+
+```ts
+import ContentBasedRecommender from 'ts-content-based-recommender'
+
+const recommender = new ContentBasedRecommender({
+  algorithm: 'bm25',
+  language: 'ja',
+  maxSimilarDocuments: 5,
+  minScore: 0,
+});
+
+const documents = [
+  {
+    id: 'post-1',
+    title: '日本語検索設計',
+    content: 'MiniSearch で日本語 BM25 検索を扱うときの設計ポイント',
+  },
+  {
+    id: 'post-2',
+    title: '検索インデックス最適化',
+    content: 'BM25 スコアと日本語トークン化の基礎を整理する',
+  },
+  {
+    id: 'post-3',
+    title: '決済基盤運用',
+    content: '障害対応フローと監視設計のまとめ',
+  },
+];
+
+await recommender.train(documents);
+
+console.log(recommender.getSimilarDocuments('post-1'));
+```
+
+BM25 scores are raw ranking scores and are not normalized to the 0-1 range.
 
 ### Multi collection
 
@@ -257,6 +299,35 @@ Is it possible to use javascript for machine learning? related tags: [ 'machine 
 */
 
 ```
+
+## Benchmark
+
+Run all benchmark scenarios:
+
+```bash
+npm run benchmark
+```
+
+Run BM25 only for the mixed Japanese dataset:
+
+```bash
+npm run benchmark -- --dataset evaluation-ja-mixed --algorithm bm25
+```
+
+### Latest Benchmark Snapshot
+
+The following results were measured locally on 2026-05-31 after reducing Japanese preprocessing memory usage by removing duplicate morphological analysis and keeping the memory-efficient local preprocessing path. Values depend on machine, Node.js runtime, and current dependency versions.
+
+| Dataset | Algorithm | Train ms | Warm avg ms | Warm p95 ms | RSS delta MB | Precision@5 | Recall@5 | Avg tag overlap@5 |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| evaluation-en | tfidf | 25.691 | 0.000035 | 0.000051 | 16.703 | 0.123 | 0.123 | 0.151 |
+| evaluation-en | lsa | 86.285 | 0.000020 | 0.000044 | 40.125 | 0.120 | 0.120 | 0.120 |
+| evaluation-en | bm25 | 23.851 | 0.000016 | 0.000034 | 15.547 | 0.127 | 0.127 | 0.154 |
+| evaluation-ja-mixed | tfidf | 170.781 | 0.000019 | 0.000032 | 356.578 | 0.050 | 0.050 | 0.050 |
+| evaluation-ja-mixed | lsa | 209.024 | 0.000035 | 0.000052 | 396.422 | 0.070 | 0.070 | 0.070 |
+| evaluation-ja-mixed | bm25 | 182.513 | 0.000015 | 0.000034 | 353.156 | 0.060 | 0.060 | 0.061 |
+
+For this snapshot, BM25 is the strongest option on the English dataset, while LSA has the best accuracy on the mixed Japanese dataset. BM25 remains the fastest inference path across both datasets.
 
 ### Japanese Language Example
 

--- a/benchmark/lsa-comparison.ts
+++ b/benchmark/lsa-comparison.ts
@@ -236,8 +236,10 @@ async function runAllBenchmarks(): Promise<void> {
   const scenarios: Array<{ dataset: keyof typeof datasets; algorithm: RecommenderAlgorithm }> = [
     { dataset: 'evaluation-en', algorithm: 'tfidf' },
     { dataset: 'evaluation-en', algorithm: 'lsa' },
+    { dataset: 'evaluation-en', algorithm: 'bm25' },
     { dataset: 'evaluation-ja-mixed', algorithm: 'tfidf' },
     { dataset: 'evaluation-ja-mixed', algorithm: 'lsa' },
+    { dataset: 'evaluation-ja-mixed', algorithm: 'bm25' },
   ];
   const results: BenchmarkResult[] = [];
 
@@ -259,7 +261,7 @@ async function runAllBenchmarks(): Promise<void> {
     results.push(JSON.parse(jsonLine) as BenchmarkResult);
   }
 
-  console.log('LSA benchmark results');
+  console.log('Recommender benchmark results');
   console.table(results.map((result) => ({
     dataset: result.dataset,
     algorithm: result.algorithm,

--- a/package-lock.json
+++ b/package-lock.json
@@ -772,16 +772,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/afinn-165": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-2.0.2.tgz",
-      "integrity": "sha512-mJ/RLUfpXfQA6bzugv+bBsc/QYkVrKaLYeS8fWBpKbTCsonv4iuV9ET0fgReEunm9vKLkaNgnekuSNlTC3WQ1Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/afinn-165-financialmarketnews": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/afinn-165-financialmarketnews/-/afinn-165-financialmarketnews-3.0.0.tgz",
@@ -3609,6 +3599,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/natural/node_modules/afinn-165": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-1.0.4.tgz",
+      "integrity": "sha512-7+Wlx3BImrK0HiG6y3lU4xX7SpBPSSu8T9iguPMlaueRFxjbYwAQrp9lqZUuFikqKbd/en8lVREILvP2J80uJA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "eslint": "^8.57.1",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.32.0",
-        "mocha": "^11.7.1",
+        "mocha": "^11.3.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       },
@@ -112,9 +112,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -183,9 +183,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -293,9 +293,9 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
-      "integrity": "sha512-zlayKCsIjYb7/IdfqxorK5+xUMyi4vOKcFy10wKJYc63NSdKI8mNME+uJqfatkPmOSMMUiojrL58IePKBm3gvQ==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
+      "integrity": "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==",
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
@@ -351,63 +351,76 @@
       }
     },
     "node_modules/@redis/bloom": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
-      "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+      "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@redis/client": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
-      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+      "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "cluster-key-slot": "1.1.2",
-        "generic-pool": "3.9.0",
-        "yallist": "4.0.0"
+        "cluster-key-slot": "1.1.2"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@redis/graph": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@redis/graph/-/graph-1.1.1.tgz",
-      "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
-      "license": "MIT",
+        "node": ">= 18.19.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@redis/json": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@redis/json/-/json-1.0.7.tgz",
-      "integrity": "sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+      "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@redis/search": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@redis/search/-/search-1.2.0.tgz",
-      "integrity": "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+      "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@redis/time-series": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-1.1.0.tgz",
-      "integrity": "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+      "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
       "peerDependencies": {
-        "@redis/client": "^1.0.0"
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -530,9 +543,9 @@
       "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
-      "version": "11.0.5",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
-      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
       "license": "MIT",
       "dependencies": {
         "@types/webidl-conversions": "*"
@@ -818,9 +831,9 @@
       }
     },
     "node_modules/afinn-165": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-1.0.4.tgz",
-      "integrity": "sha512-7+Wlx3BImrK0HiG6y3lU4xX7SpBPSSu8T9iguPMlaueRFxjbYwAQrp9lqZUuFikqKbd/en8lVREILvP2J80uJA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/afinn-165/-/afinn-165-2.0.2.tgz",
+      "integrity": "sha512-mJ/RLUfpXfQA6bzugv+bBsc/QYkVrKaLYeS8fWBpKbTCsonv4iuV9ET0fgReEunm9vKLkaNgnekuSNlTC3WQ1Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -838,9 +851,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -868,6 +881,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1079,22 +1093,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1122,12 +1124,12 @@
       "license": "ISC"
     },
     "node_modules/bson": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
-      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
+      "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/call-bind": {
@@ -1153,6 +1155,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1166,6 +1169,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -1224,6 +1228,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -1333,6 +1338,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1345,6 +1351,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -1360,15 +1367,6 @@
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/corser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
-      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1469,6 +1467,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1552,9 +1551,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1575,9 +1574,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -1596,6 +1595,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -1693,6 +1693,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1702,6 +1703,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1711,6 +1713,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1963,9 +1966,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1997,9 +2000,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2050,9 +2053,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2071,9 +2074,9 @@
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2146,12 +2149,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2283,31 +2280,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -2353,6 +2330,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2389,15 +2367,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/generic-pool": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
-      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2422,6 +2391,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2446,6 +2416,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -2474,9 +2445,10 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2544,6 +2516,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2576,6 +2549,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2614,6 +2588,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2642,6 +2617,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2654,74 +2630,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "he": "bin/he"
-      }
-    },
-    "node_modules/html-encoding-sniffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
-      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-encoding": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/http-server": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
-      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
-      "license": "MIT",
-      "dependencies": {
-        "basic-auth": "^2.0.1",
-        "chalk": "^4.1.2",
-        "corser": "^2.0.1",
-        "he": "^1.2.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy": "^1.18.1",
-        "mime": "^1.6.0",
-        "minimist": "^1.2.6",
-        "opener": "^1.5.1",
-        "portfinder": "^1.0.28",
-        "secure-compare": "3.0.1",
-        "union": "~0.5.0",
-        "url-join": "^4.0.1"
-      },
-      "bin": {
-        "http-server": "bin/http-server"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3266,9 +3178,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3313,12 +3225,12 @@
       }
     },
     "node_modules/kareem": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
-      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-3.3.0.tgz",
+      "integrity": "sha512-kpSuLD3/7RenBnjnJdOHXCKC8dTd1JzeOiJhN0necWWci6cC+qX+VuwPnMVgb+a4+KNJSfgqahpnfWaeDXCimw==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/keyv": {
@@ -3373,9 +3285,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -3430,6 +3342,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3474,26 +3387,14 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -3506,6 +3407,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3567,29 +3469,29 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.1.tgz",
-      "integrity": "sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.3.0.tgz",
+      "integrity": "sha512-J0RLIM89xi8y6l77bgbX+03PeBRDQCOVQpnwOcCN7b8hCmbh6JvGI2ZDJ5WMoHz+IaPU+S4lvTd0j51GmBAdgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^7.0.0",
+        "diff": "^5.2.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
         "he": "^1.2.0",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
-        "minimatch": "^9.0.5",
+        "minimatch": "^5.1.6",
         "ms": "^2.1.3",
         "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
-        "workerpool": "^9.2.0",
+        "workerpool": "^6.5.1",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
@@ -3600,6 +3502,19 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mocha/node_modules/supports-color": {
@@ -3619,26 +3534,26 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.17.0.tgz",
-      "integrity": "sha512-neerUzg/8U26cgruLysKEjJvoNSXhyID3RvzvdcpsIi2COYM3FS3o9nlH7fxFtefTb942dX3W9i37oPfCVj4wA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.2.0.tgz",
+      "integrity": "sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.4",
-        "mongodb-connection-string-url": "^3.0.0"
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^7.2.0",
+        "mongodb-connection-string-url": "^7.0.0"
       },
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
-        "gcp-metadata": "^5.2.0",
-        "kerberos": "^2.0.1",
-        "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
-        "socks": "^2.7.1"
+        "@aws-sdk/credential-providers": "^3.806.0",
+        "@mongodb-js/zstd": "^7.0.0",
+        "gcp-metadata": "^7.0.1",
+        "kerberos": "^7.0.0",
+        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+        "snappy": "^7.3.2",
+        "socks": "^2.8.6"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
@@ -3665,31 +3580,33 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
-      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
+      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/whatwg-url": "^11.0.2",
-        "whatwg-url": "^14.1.0 || ^13.0.0"
+        "@types/whatwg-url": "^13.0.0",
+        "whatwg-url": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/mongoose": {
-      "version": "8.16.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.16.1.tgz",
-      "integrity": "sha512-Q+0TC+KLdY4SYE+u9gk9pdW1tWu/pl0jusyEkMGTgBoAbvwQdfy4f9IM8dmvCwb/blSfp7IfLkob7v76x6ZGpQ==",
+      "version": "9.6.3",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.6.3.tgz",
+      "integrity": "sha512-vI6dTTlQnfMCyyQ5TrvhG0bCRs4dq5e1uFNPtOOWsOhn0fSg8AoIHjfyyCYr8aybyvPs845dRHGxsC3w/fHcBA==",
       "license": "MIT",
       "dependencies": {
-        "bson": "^6.10.4",
-        "kareem": "2.6.3",
-        "mongodb": "~6.17.0",
+        "kareem": "3.3.0",
+        "mongodb": "~7.2",
         "mpath": "0.9.0",
-        "mquery": "5.0.0",
+        "mquery": "6.0.0",
         "ms": "2.1.3",
         "sift": "17.1.3"
       },
       "engines": {
-        "node": ">=16.20.1"
+        "node": ">=20.19.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3706,15 +3623,12 @@
       }
     },
     "node_modules/mquery": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
-      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-6.0.0.tgz",
+      "integrity": "sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==",
       "license": "MIT",
-      "dependencies": {
-        "debug": "4.x"
-      },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/ms": {
@@ -3724,26 +3638,25 @@
       "license": "MIT"
     },
     "node_modules/natural": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/natural/-/natural-8.1.0.tgz",
-      "integrity": "sha512-qHKU+BzPXzEDwToFBzlI+3oI2jeN3xRNP421ifoF2Fw7ej+5zEO3Z5wUKPjz00jhz9/ESerIUGfhPqqkOqlWPA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/natural/-/natural-8.1.1.tgz",
+      "integrity": "sha512-Ucb+lsUcGxUqu3rn8cwHjT6gJQosO63nIX/aBQXB3+IDkNbFV7PuviysO+Rzz3aKn7PZhPj3bNF4PS9gDVjYCQ==",
       "license": "MIT",
       "dependencies": {
-        "afinn-165": "^1.0.2",
+        "afinn-165": "^2.0.2",
         "afinn-165-financialmarketnews": "^3.0.0",
         "apparatus": "^0.0.10",
-        "dotenv": "^16.4.5",
-        "http-server": "^14.1.1",
+        "dotenv": "^17.3.1",
         "memjs": "^1.3.2",
-        "mongoose": "^8.2.0",
-        "pg": "^8.11.3",
-        "redis": "^4.6.13",
-        "safe-stable-stringify": "^2.2.0",
+        "mongoose": "^9.2.1",
+        "pg": "^8.18.0",
+        "redis": "^5.11.0",
+        "safe-stable-stringify": "^2.5.0",
         "stopwords-iso": "^1.1.0",
-        "sylvester": "^0.0.12",
-        "underscore": "^1.9.1",
-        "uuid": "^9.0.1",
-        "wordnet-db": "^3.1.11"
+        "sylvester": "^0.0.21",
+        "underscore": "^1.13.0",
+        "uuid": "^13.0.0",
+        "wordnet-db": "^3.1.14"
       },
       "engines": {
         "node": ">=0.4.10"
@@ -3760,6 +3673,7 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3876,15 +3790,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/opener": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
-      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
-      "license": "(WTFPL OR MIT)",
-      "bin": {
-        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -4040,15 +3945,15 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.16.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
-      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "pg-connection-string": "^2.9.1",
-        "pg-pool": "^3.10.1",
-        "pg-protocol": "^1.10.3",
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -4056,7 +3961,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.2.7"
+        "pg-cloudflare": "^1.4.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -4068,16 +3973,16 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
-      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
-      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
@@ -4090,18 +3995,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
-      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -4137,9 +4042,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4148,25 +4053,6 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/portfinder": {
-      "version": "1.0.37",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.37.tgz",
-      "integrity": "sha512-yuGIEjDAYnnOex9ddMnKZEMFE0CcGo6zbfzDklkmT1m5z734ss6JMzN9rNB3+RR7iS+F10D4/BVIaXOyh8PQKw==",
-      "license": "MIT",
-      "dependencies": {
-        "async": "^3.2.6",
-        "debug": "^4.3.6"
-      },
-      "engines": {
-        "node": ">= 10.12"
-      }
-    },
-    "node_modules/portfinder/node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -4188,9 +4074,9 @@
       }
     },
     "node_modules/postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4234,21 +4120,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -4297,20 +4168,19 @@
       }
     },
     "node_modules/redis": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-4.7.1.tgz",
-      "integrity": "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==",
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+      "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
       "license": "MIT",
-      "workspaces": [
-        "./packages/*"
-      ],
       "dependencies": {
-        "@redis/bloom": "1.2.0",
-        "@redis/client": "1.6.1",
-        "@redis/graph": "1.1.1",
-        "@redis/json": "1.0.7",
-        "@redis/search": "1.2.0",
-        "@redis/time-series": "1.1.0"
+        "@redis/bloom": "5.12.1",
+        "@redis/client": "5.12.1",
+        "@redis/json": "5.12.1",
+        "@redis/search": "5.12.1",
+        "@redis/time-series": "5.12.1"
+      },
+      "engines": {
+        "node": ">= 18.19.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -4366,12 +4236,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -4433,9 +4297,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4466,9 +4330,9 @@
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4526,6 +4390,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-push-apply": {
@@ -4571,18 +4436,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
-    "node_modules/secure-compare": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
-      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -4683,6 +4536,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4702,6 +4556,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4718,6 +4573,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -4736,6 +4592,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5006,6 +4863,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5028,9 +4886,9 @@
       }
     },
     "node_modules/sylvester": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.12.tgz",
-      "integrity": "sha512-SzRP5LQ6Ts2G5NyAa/jg16s8e3R7rfdFjizy1zeoecYWw+nGL+YA1xZvW/+iJmidBGSdLkuvdwTYEyJEb+EiUw==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/sylvester/-/sylvester-0.0.21.tgz",
+      "integrity": "sha512-yUT0ukFkFEt4nb+NY+n2ag51aS/u9UHXoZw+A4jgD77/jzZsBoSDHuqysrVCBC4CYR4TYvUJq54ONpXgDBH8tA==",
       "engines": {
         "node": ">=0.2.6"
       }
@@ -5125,9 +4983,9 @@
       }
     },
     "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -5296,9 +5154,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "license": "MIT"
     },
     "node_modules/undici-types": {
@@ -5307,17 +5165,6 @@
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/union": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
-      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
-      "dependencies": {
-        "qs": "^6.4.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -5329,23 +5176,17 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "license": "MIT"
-    },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -5366,18 +5207,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
-      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
       "engines": {
         "node": ">=12"
       }
@@ -5520,9 +5349,9 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.3.tgz",
-      "integrity": "sha512-slxCaKbYjEdFT/o2rH9xS1hf4uRDch1w7Uo+apxhZ+sf/1d9e0ZVkn42kPNGP2dgjIx6YFvSevj0zHvbWe2jdw==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -5652,12 +5481,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/kuromoji": "^0.1.3",
         "kuromoji": "^0.1.2",
+        "minisearch": "^7.2.0",
         "ml-matrix": "^6.12.1",
         "natural": "^8.1.0",
         "stopword": "^3.1.5",
@@ -3519,6 +3520,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
     },
     "node_modules/ml-array-max": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "eslint": "^8.57.1",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.32.0",
-        "mocha": "^11.3.0",
+        "mocha": "^10.8.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       },
@@ -217,53 +217,6 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -337,17 +290,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@redis/bloom": {
@@ -867,6 +809,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -891,6 +843,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/apparatus": {
@@ -1093,6 +1059,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
@@ -1255,74 +1234,53 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 8.10.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
+        "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/cluster-key-slot": {
@@ -1606,17 +1564,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
@@ -2302,29 +2253,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -2445,22 +2394,21 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2477,6 +2425,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/globals": {
@@ -2765,6 +2726,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -3161,22 +3135,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3324,13 +3282,6 @@
         "get-func-name": "^2.0.1"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -3413,16 +3364,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/minisearch": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
@@ -3469,31 +3410,31 @@
       }
     },
     "node_modules/mocha": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.3.0.tgz",
-      "integrity": "sha512-J0RLIM89xi8y6l77bgbX+03PeBRDQCOVQpnwOcCN7b8hCmbh6JvGI2ZDJ5WMoHz+IaPU+S4lvTd0j51GmBAdgQ==",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",
-        "chokidar": "^4.0.1",
+        "chokidar": "^3.5.3",
         "debug": "^4.3.5",
         "diff": "^5.2.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
-        "glob": "^10.4.5",
+        "glob": "^8.1.0",
         "he": "^1.2.0",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
         "minimatch": "^5.1.6",
         "ms": "^2.1.3",
-        "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
         "workerpool": "^6.5.1",
-        "yargs": "^17.7.2",
-        "yargs-parser": "^21.1.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
         "yargs-unparser": "^2.0.0"
       },
       "bin": {
@@ -3501,7 +3442,7 @@
         "mocha": "bin/mocha.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
@@ -3668,6 +3609,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -3860,13 +3811,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3916,23 +3860,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/pathval": {
       "version": "1.1.1",
@@ -4033,13 +3960,6 @@
       "dependencies": {
         "split2": "^4.1.0"
       }
-    },
-    "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.2",
@@ -4154,17 +4074,16 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
+      "dependencies": {
+        "picomatch": "^2.2.1"
       },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/redis": {
@@ -4614,19 +4533,6 @@
       "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
       "license": "MIT"
     },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -4675,25 +4581,6 @@
       }
     },
     "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
@@ -4706,42 +4593,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/string.prototype.trim": {
@@ -4804,20 +4655,6 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -5356,25 +5193,6 @@
       "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
@@ -5390,70 +5208,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {
@@ -5483,32 +5237,32 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cliui": "^8.0.1",
+        "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
+        "string-width": "^4.2.0",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
+        "yargs-parser": "^20.2.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       }
     },
     "node_modules/yargs-unparser": {
@@ -5525,28 +5279,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "npx tsc --noEmit && eslint 'src/**/*.ts' 'test/**/*.ts'",
     "lint:fix": "eslint 'src/**/*.ts' 'test/**/*.ts' --fix",
     "tsc": "tsc --noEmit",
-    "test": "npm run build && mocha dist/test/**/*.js",
+    "test": "npm run build && mocha --no-config --timeout 10000 --recursive 'dist/test/**/*.js'",
     "test:ts": "cross-env NODE_OPTIONS='--loader=ts-node/esm' mocha test/**/*.ts",
     "benchmark": "node --loader ts-node/esm benchmark/lsa-comparison.ts",
     "benchmark:lsa": "node --loader ts-node/esm benchmark/lsa-comparison.ts",
@@ -108,5 +108,8 @@
   },
   "peerDependencies": {
     "typescript": ">=4.5.0"
+  },
+  "overrides": {
+    "afinn-165": "1.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
   "dependencies": {
     "@types/kuromoji": "^0.1.3",
     "kuromoji": "^0.1.2",
-    "ml-matrix": "^6.12.1",
     "minisearch": "^7.2.0",
+    "ml-matrix": "^6.12.1",
     "natural": "^8.1.0",
     "stopword": "^3.1.5",
     "striptags": "^3.2.0",
@@ -96,7 +96,7 @@
     "eslint": "^8.57.1",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.32.0",
-    "mocha": "^11.7.1",
+    "mocha": "^11.3.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "tsc": "tsc --noEmit",
     "test": "npm run build && mocha dist/test/**/*.js",
     "test:ts": "cross-env NODE_OPTIONS='--loader=ts-node/esm' mocha test/**/*.ts",
+    "benchmark": "node --loader ts-node/esm benchmark/lsa-comparison.ts",
     "benchmark:lsa": "node --loader ts-node/esm benchmark/lsa-comparison.ts",
     "example": "node --loader ts-node/esm example/example.ts",
     "dev": "node --loader ts-node/esm"
@@ -74,6 +75,7 @@
     "@types/kuromoji": "^0.1.3",
     "kuromoji": "^0.1.2",
     "ml-matrix": "^6.12.1",
+    "minisearch": "^7.2.0",
     "natural": "^8.1.0",
     "stopword": "^3.1.5",
     "striptags": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "author": "Ken Sakurai <monotalk.xyz@gmail.com>",
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=20.0.0",
     "npm": ">=9.0.0"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "eslint": "^8.57.1",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.32.0",
-    "mocha": "^11.3.0",
+    "mocha": "^10.8.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   },

--- a/src/lib/ContentBasedRecommender.ts
+++ b/src/lib/ContentBasedRecommender.ts
@@ -1,51 +1,15 @@
-import * as _ from 'underscore';
-import Vector from 'vector-object';
-import { Matrix, SingularValueDecomposition } from 'ml-matrix';
 import {
   Document,
   RecommenderOptions,
   SimilarDocument,
   ExportedModel,
-  ProcessedDocument,
   ProcessingPipeline,
 } from '../types/index.js';
 import { ProcessingPipelineFactory } from './factories/ProcessingPipelineFactory.js';
-import { JapaneseTokenizer } from './tokenizers/JapaneseTokenizer.js';
-import { EnglishTokenFilter } from './filters/EnglishTokenFilter.js';
-import { JapaneseTokenFilter } from './filters/JapaneseTokenFilter.js';
-import natural from 'natural';
-
-const { TfIdf } = natural;
-
-/**
- * デフォルト設定オプション
- */
-const defaultOptions: RecommenderOptions = {
-  maxVectorSize: 100,
-  maxSimilarDocuments: Number.MAX_SAFE_INTEGER,
-  minScore: 0,
-  debug: false,
-  algorithm: 'tfidf',
-  language: 'en',
-  lsaDimensions: 12,
-  tokenFilterOptions: {
-    removeDuplicates: true,
-    removeStopwords: true,
-    customStopWords: [],
-    minTokenLength: 1,
-    allowedPos: ['名詞', '動詞', '形容詞']
-  }
-};
-
-/**
- * 文書ベクトルインターフェース
- */
-interface DocumentVector {
-  /** 文書ID */
-  id: string;
-  /** ベクトルオブジェクト */
-  vector: Vector;
-}
+import { TrainingStrategyFactory } from './factories/TrainingStrategyFactory.js';
+import { RecommenderOptionsResolver } from './services/RecommenderOptionsResolver.js';
+import { RecommenderValidator } from './services/RecommenderValidator.js';
+import { RecommenderTrainingContext } from './strategies/RecommenderTrainingStrategy.js';
 
 /**
  * コンテンツベース推薦システムのメインクラス
@@ -79,42 +43,17 @@ class ContentBasedRecommender {
    * @throws {Error} 無効なオプションが指定された場合
    */
   public setOptions(options: RecommenderOptions = {}): void {
-    // バリデーション
-    if ((options.maxVectorSize !== undefined) &&
-      (!Number.isInteger(options.maxVectorSize) || options.maxVectorSize <= 0)) {
-      throw new Error('The option maxVectorSize should be integer and greater than 0');
-    }
-
-    if ((options.maxSimilarDocuments !== undefined) &&
-      (!Number.isInteger(options.maxSimilarDocuments) || options.maxSimilarDocuments <= 0)) {
-      throw new Error('The option maxSimilarDocuments should be integer and greater than 0');
-    }
-
-    if ((options.minScore !== undefined) &&
-      (!_.isNumber(options.minScore) || options.minScore < 0 || options.minScore > 1)) {
-      throw new Error('The option minScore should be a number between 0 and 1');
-    }
-
-    if ((options.algorithm !== undefined) &&
-      (!_.isString(options.algorithm) || !['tfidf', 'lsa'].includes(options.algorithm))) {
-      throw new Error('The option algorithm should be either "tfidf" or "lsa"');
-    }
-
-    if ((options.language !== undefined) &&
-      (!_.isString(options.language) || !['en', 'ja'].includes(options.language))) {
-      throw new Error('The option language should be either "en" or "ja"');
-    }
-
-    if ((options.lsaDimensions !== undefined) &&
-      (!Number.isInteger(options.lsaDimensions) || options.lsaDimensions <= 0)) {
-      throw new Error('The option lsaDimensions should be integer and greater than 0');
-    }
+    RecommenderValidator.validateOptions(options);
 
     const prevLanguage = this.options?.language;
-    this.options = Object.assign({}, defaultOptions, options);
+    const prevTokenFilterOptions = this.options?.tokenFilterOptions;
+    this.options = RecommenderOptionsResolver.resolveOptions(options);
 
-    // 言語が変更された場合、処理パイプラインを再初期化
-    if (this.pipeline && prevLanguage !== this.options.language) {
+    // 言語またはフィルター条件が変更された場合、処理パイプラインを再初期化
+    if (this.pipeline && (
+      prevLanguage !== this.options.language ||
+      JSON.stringify(prevTokenFilterOptions) !== JSON.stringify(this.options.tokenFilterOptions)
+    )) {
       this.pipeline = ProcessingPipelineFactory.createPipeline(this.options.language!, this.options.tokenFilterOptions);
     }
   }
@@ -125,19 +64,8 @@ class ContentBasedRecommender {
    */
   public async train(documents: Document[]): Promise<void> {
     this.validateDocuments(documents);
-
-    if (this.options.debug) {
-      console.log(`Total documents: ${documents.length}`);
-    }
-
-    // ステップ1 - 文書の前処理
-    const preprocessDocs = await this._preprocessDocuments(documents, this.options);
-
-    // ステップ2 - 文書ベクトルの作成
-    const docVectors = this._produceWordVectors(preprocessDocs, this.options);
-
-    // ステップ3 - 類似度の計算
-    this.data = this._calculateSimilarities(docVectors, this.options);
+    const trainingStrategy = TrainingStrategyFactory.create(this.options.algorithm);
+    this.data = await trainingStrategy.train(documents, this.createTrainingContext());
   }
 
   /**
@@ -148,24 +76,8 @@ class ContentBasedRecommender {
   public async trainBidirectional(documents: Document[], targetDocuments: Document[]): Promise<void> {
     this.validateDocuments(documents);
     this.validateDocuments(targetDocuments);
-
-    if (this.options.debug) {
-      console.log(`Total documents: ${documents.length}`);
-    }
-
-    // ステップ1 - 文書の前処理
-    const preprocessDocs = await this._preprocessDocuments(documents, this.options);
-    const preprocessTargetDocs = await this._preprocessDocuments(targetDocuments, this.options);
-
-    // ステップ2 - 文書ベクトルの作成
-    const { documentVectors: docVectors, targetDocumentVectors: targetDocVectors } = this._produceBidirectionalWordVectors(
-      preprocessDocs,
-      preprocessTargetDocs,
-      this.options
-    );
-
-    // ステップ3 - 類似度の計算
-    this.data = this._calculateSimilaritiesBetweenTwoVectors(docVectors, targetDocVectors, this.options);
+    const trainingStrategy = TrainingStrategyFactory.create(this.options.algorithm);
+    this.data = await trainingStrategy.trainBidirectional(documents, targetDocuments, this.createTrainingContext());
   }
 
   /**
@@ -174,21 +86,7 @@ class ContentBasedRecommender {
    * @throws {Error} 無効な文書配列が指定された場合
    */
   public validateDocuments(documents: Document[]): void {
-    if (!_.isArray(documents)) {
-      throw new Error('Documents should be an array of objects');
-    }
-
-    for (let i = 0; i < documents.length; i += 1) {
-      const document = documents[i];
-
-      if (!_.has(document, 'id') || !_.has(document, 'content')) {
-        throw new Error('Documents should be have fields id and content');
-      }
-
-      if (_.has(document, 'tokens') || _.has(document, 'vector')) {
-        throw new Error('"tokens" and "vector" properties are reserved and cannot be used as document properties');
-      }
-    }
+    RecommenderValidator.validateDocuments(documents);
   }
 
   /**
@@ -240,372 +138,14 @@ class ContentBasedRecommender {
   // プライベートメソッド
 
   /**
-   * 文書の前処理（トークン化、ステミング等）
-   * @param documents 対象文書配列
-   * @param options 設定オプション
-   * @returns 前処理済み文書配列
+   * 学習戦略向けの実行コンテキストを生成する
+   * @returns 学習コンテキスト
    */
-  private async _preprocessDocuments(documents: Document[], options: RecommenderOptions): Promise<ProcessedDocument[]> {
-    if (options.debug) {
-      console.log('Preprocessing documents');
-    }
-
-    const processedDocuments = await Promise.all(documents.map(async item => {
-      const tokens = await this._getTokensFromString(item.content);
-      return {
-        id: item.id,
-        tokens,
-        originalDocument: item,
-      };
-    }));
-
-    return processedDocuments;
-  }
-
-  /**
-   * 文字列からトークンを抽出する
-   * @param string 対象文字列
-   * @returns トークン配列のPromise
-   */
-  private async _getTokensFromString(string: string): Promise<string[]> {
-    // トークン化
-    const rawTokens = await this.pipeline.tokenizer.tokenize(string);
-
-    // フィルタリング
-    if (this.options.language === 'ja') {
-      // 日本語の場合、品詞情報を含む詳細トークンを取得してフィルタリング
-      const japaneseTokenizer = this.pipeline.tokenizer as JapaneseTokenizer;
-      const japaneseFilter = this.pipeline.filter as JapaneseTokenFilter;
-      const detailedTokens = await japaneseTokenizer.getDetailedJapaneseTokens(string);
-      return japaneseFilter.filterWithPos(detailedTokens);
-    } else if (this.options.language === 'en') {
-      // 英語の場合、N-gram対応フィルタリング
-      const englishFilter = this.pipeline.filter as EnglishTokenFilter;
-      return englishFilter.filterWithNgrams(rawTokens);
-    } else {
-      // その他の場合、通常のフィルタリング
-      return this.pipeline.filter.filter(rawTokens);
-    }
-  }
-
-  /**
-   * 類似文書を降順でソートし、最大数を制限する
-   * @param data 類似度データ
-   * @param options 設定オプション
-   */
-  private orderDocuments(data: Record<string, SimilarDocument[]>, options: RecommenderOptions): void {
-    // 類似文書を降順でソート
-    Object.keys(data)
-      .forEach((id) => {
-        data[id].sort((a, b) => b.score - a.score);
-
-        if (data[id].length > options.maxSimilarDocuments!) {
-          data[id] = data[id].slice(0, options.maxSimilarDocuments);
-        }
-      });
-  }
-
-  /**
-   * 文書ベクトルを生成する
-   * @param processedDocuments 前処理済み文書配列
-   * @param options 設定オプション
-   * @returns 文書ベクトル配列
-   */
-  private _produceWordVectors(processedDocuments: ProcessedDocument[], options: RecommenderOptions): DocumentVector[] {
-    if (options.algorithm === 'lsa') {
-      return this._produceLsaWordVectors(processedDocuments, options);
-    }
-
-    return this._produceTfIdfWordVectors(processedDocuments, options);
-  }
-
-  /**
-   * 双方向学習向けに文書ベクトルを生成する
-   * @param processedDocuments メイン文書配列
-   * @param targetProcessedDocuments ターゲット文書配列
-   * @param options 設定オプション
-   * @returns 生成済みベクトル
-   */
-  private _produceBidirectionalWordVectors(
-    processedDocuments: ProcessedDocument[],
-    targetProcessedDocuments: ProcessedDocument[],
-    options: RecommenderOptions
-  ): { documentVectors: DocumentVector[]; targetDocumentVectors: DocumentVector[] } {
-    if (options.algorithm !== 'lsa') {
-      return {
-        documentVectors: this._produceTfIdfWordVectors(processedDocuments, options),
-        targetDocumentVectors: this._produceTfIdfWordVectors(targetProcessedDocuments, options)
-      };
-    }
-
-    const allDocuments = processedDocuments.concat(targetProcessedDocuments);
-    const allVectors = this._produceLsaWordVectors(allDocuments, options);
-    const splitIndex = processedDocuments.length;
-
+  private createTrainingContext(): RecommenderTrainingContext {
     return {
-      documentVectors: allVectors.slice(0, splitIndex),
-      targetDocumentVectors: allVectors.slice(splitIndex)
+      options: this.options,
+      pipeline: this.pipeline,
     };
-  }
-
-  /**
-   * TF-IDFベースの文書ベクトルを生成する
-   * @param processedDocuments 前処理済み文書配列
-   * @param options 設定オプション
-   * @returns 文書ベクトル配列
-   */
-  private _produceTfIdfWordVectors(processedDocuments: ProcessedDocument[], options: RecommenderOptions): DocumentVector[] {
-    // TF-IDFの処理
-    const tfidf = new TfIdf();
-
-    processedDocuments.forEach((processedDocument) => {
-      tfidf.addDocument(processedDocument.tokens);
-    });
-
-    // ワードベクトルの作成
-    const documentVectors: DocumentVector[] = [];
-
-    for (let i = 0; i < processedDocuments.length; i += 1) {
-      if (options.debug) {
-        console.log(`Creating word vector for document ${i}`);
-      }
-
-      const processedDocument = processedDocuments[i];
-      const hash: Record<string, number> = {};
-
-      const items = tfidf.listTerms(i);
-      const maxSize = Math.min(options.maxVectorSize!, items.length);
-      for (let j = 0; j < maxSize; j += 1) {
-        const item = items[j];
-        hash[item.term] = item.tfidf;
-      }
-
-      const documentVector: DocumentVector = {
-        id: processedDocument.id,
-        vector: new Vector(hash),
-      };
-
-      documentVectors.push(documentVector);
-    }
-
-    return documentVectors;
-  }
-
-  /**
-   * LSAベースの文書ベクトルを生成する
-   * @param processedDocuments 前処理済み文書配列
-   * @param options 設定オプション
-   * @returns 文書ベクトル配列
-   */
-  private _produceLsaWordVectors(processedDocuments: ProcessedDocument[], options: RecommenderOptions): DocumentVector[] {
-    if (processedDocuments.length === 0) {
-      return [];
-    }
-
-    const { matrix } = this._buildTfIdfMatrix(processedDocuments);
-    if (matrix.columns === 0) {
-      return this._createZeroVectors(processedDocuments);
-    }
-
-    const shouldTranspose = matrix.columns > matrix.rows;
-    const matrixForSvd = shouldTranspose ? matrix.transpose() : matrix;
-    const svd = new SingularValueDecomposition(matrixForSvd, {
-      autoTranspose: false,
-    });
-    const singularValues = svd.diagonal;
-    if (singularValues.length === 0) {
-      return this._createZeroVectors(processedDocuments);
-    }
-
-    const latentDimensions = Math.min(options.lsaDimensions!, singularValues.length);
-    const documentBasis = shouldTranspose
-      ? svd.rightSingularVectors.subMatrix(0, processedDocuments.length - 1, 0, latentDimensions - 1)
-      : svd.leftSingularVectors.subMatrix(0, processedDocuments.length - 1, 0, latentDimensions - 1);
-    const truncatedDiagonal = Matrix.diag(singularValues.slice(0, latentDimensions));
-    const reducedMatrix = documentBasis.mmul(truncatedDiagonal);
-
-    return processedDocuments.map((processedDocument, index) => {
-      const hash: Record<string, number> = {};
-
-      for (let dimensionIndex = 0; dimensionIndex < latentDimensions; dimensionIndex += 1) {
-        hash[`dim_${dimensionIndex}`] = reducedMatrix.get(index, dimensionIndex);
-      }
-
-      return {
-        id: processedDocument.id,
-        vector: new Vector(hash),
-      };
-    });
-  }
-
-  /**
-   * LSA用のTF-IDF行列を構築する
-   * @param processedDocuments 前処理済み文書配列
-   * @returns TF-IDF行列
-   */
-  private _buildTfIdfMatrix(processedDocuments: ProcessedDocument[]): { matrix: Matrix; terms: string[] } {
-    const termSet = new Set<string>();
-    const termDocumentFrequency = new Map<string, number>();
-
-    processedDocuments.forEach((processedDocument) => {
-      const uniqueTerms = new Set(processedDocument.tokens);
-
-      processedDocument.tokens.forEach((token) => {
-        termSet.add(token);
-      });
-
-      uniqueTerms.forEach((term) => {
-        termDocumentFrequency.set(term, (termDocumentFrequency.get(term) ?? 0) + 1);
-      });
-    });
-
-    const terms = Array.from(termSet).sort();
-    const matrix = Matrix.zeros(processedDocuments.length, terms.length);
-    const totalDocuments = processedDocuments.length;
-
-    processedDocuments.forEach((processedDocument, rowIndex) => {
-      const termFrequency = processedDocument.tokens.reduce((acc: Record<string, number>, token) => {
-        acc[token] = (acc[token] ?? 0) + 1;
-        return acc;
-      }, {});
-
-      terms.forEach((term, columnIndex) => {
-        const tf = termFrequency[term] ?? 0;
-        if (tf === 0) {
-          return;
-        }
-
-        const documentFrequency = termDocumentFrequency.get(term) ?? 0;
-        const idf = Math.log((1 + totalDocuments) / (1 + documentFrequency)) + 1;
-        matrix.set(rowIndex, columnIndex, tf * idf);
-      });
-    });
-
-    return { matrix, terms };
-  }
-
-  /**
-   * ゼロベクトルの文書ベクトル配列を生成する
-   * @param processedDocuments 前処理済み文書配列
-   * @returns 文書ベクトル配列
-   */
-  private _createZeroVectors(processedDocuments: ProcessedDocument[]): DocumentVector[] {
-    return processedDocuments.map((processedDocument) => ({
-      id: processedDocument.id,
-      vector: new Vector({}),
-    }));
-  }
-
-  /**
-   * 2つのベクトルセット間の類似度を計算する（双方向学習用）
-   * @param documentVectors メイン文書のベクトル配列
-   * @param targetDocumentVectors ターゲット文書のベクトル配列
-   * @param options 設定オプション
-   * @returns 類似度データ
-   */
-  private _calculateSimilaritiesBetweenTwoVectors(
-    documentVectors: DocumentVector[],
-    targetDocumentVectors: DocumentVector[],
-    options: RecommenderOptions
-  ): Record<string, SimilarDocument[]> {
-    const data = {
-      ...this.initializeDataHash(documentVectors),
-      ...this.initializeDataHash(targetDocumentVectors)
-    };
-
-    // 類似度スコアの計算
-    for (let i = 0; i < documentVectors.length; i += 1) {
-      if (options.debug) console.log(`Calculating similarity score for document ${i}`);
-
-      for (let j = 0; j < targetDocumentVectors.length; j += 1) {
-        const documentVectorA = documentVectors[i];
-        const targetDocumentVectorB = targetDocumentVectors[j];
-        const idi = documentVectorA.id;
-        const vi = documentVectorA.vector;
-        const idj = targetDocumentVectorB.id;
-        const vj = targetDocumentVectorB.vector;
-        const similarity = this._getCosineSimilarity(vi, vj);
-
-        if (similarity > options.minScore!) {
-          data[idi].push({
-            id: targetDocumentVectorB.id,
-            score: similarity
-          });
-          data[idj].push({
-            id: documentVectorA.id,
-            score: similarity
-          });
-        }
-      }
-    }
-
-    this.orderDocuments(data, options);
-
-    return data;
-  }
-
-  /**
-   * データハッシュを初期化する
-   * @param documentVectors 文書ベクトル配列
-   * @returns 初期化されたデータハッシュ
-   */
-  private initializeDataHash(documentVectors: DocumentVector[]): Record<string, SimilarDocument[]> {
-    return documentVectors.reduce((acc: Record<string, SimilarDocument[]>, item) => {
-      acc[item.id] = [];
-      return acc;
-    }, {});
-  }
-
-  /**
-   * 同一コレクション内の類似度を計算する
-   * @param documentVectors 文書ベクトル配列
-   * @param options 設定オプション
-   * @returns 類似度データ
-   */
-  private _calculateSimilarities(documentVectors: DocumentVector[], options: RecommenderOptions): Record<string, SimilarDocument[]> {
-    const data = { ...this.initializeDataHash(documentVectors) };
-
-    // 類似度スコアの計算
-    for (let i = 0; i < documentVectors.length; i += 1) {
-      if (options.debug) console.log(`Calculating similarity score for document ${i}`);
-
-      for (let j = 0; j < i; j += 1) {
-        const documentVectorA = documentVectors[i];
-        const idi = documentVectorA.id;
-        const vi = documentVectorA.vector;
-        const documentVectorB = documentVectors[j];
-        const idj = documentVectorB.id;
-        const vj = documentVectorB.vector;
-        const similarity = this._getCosineSimilarity(vi, vj);
-
-        if (similarity > options.minScore!) {
-          data[idi].push({
-            id: documentVectorB.id,
-            score: similarity
-          });
-
-          data[idj].push({
-            id: documentVectorA.id,
-            score: similarity
-          });
-        }
-      }
-    }
-
-    this.orderDocuments(data, options);
-
-    return data;
-  }
-
-  /**
-   * コサイン類似度を安全に取得する
-   * @param vectorA ベクトルA
-   * @param vectorB ベクトルB
-   * @returns コサイン類似度
-   */
-  private _getCosineSimilarity(vectorA: Vector, vectorB: Vector): number {
-    const similarity = vectorA.getCosineSimilarity(vectorB);
-    return Number.isFinite(similarity) ? similarity : 0;
   }
 }
 

--- a/src/lib/factories/DocumentVectorFactory.ts
+++ b/src/lib/factories/DocumentVectorFactory.ts
@@ -1,0 +1,199 @@
+import Vector from 'vector-object';
+import { Matrix, SingularValueDecomposition } from 'ml-matrix';
+import natural from 'natural';
+import {
+  ProcessedDocument,
+  RecommenderOptions,
+} from '../../types/index.js';
+import { DocumentVector } from '../services/SimilarityCalculator.js';
+
+const { TfIdf } = natural;
+
+/**
+ * 文書ベクトル生成サービス
+ */
+export class DocumentVectorFactory {
+  /**
+   * TF-IDF ベースの双方向学習用文書ベクトルを生成する
+   * @param processedDocuments メイン文書配列
+   * @param targetProcessedDocuments ターゲット文書配列
+   * @param options 設定オプション
+   * @returns 文書ベクトル配列
+   */
+  public createBidirectionalTfIdfWordVectors(
+    processedDocuments: ProcessedDocument[],
+    targetProcessedDocuments: ProcessedDocument[],
+    options: RecommenderOptions
+  ): { documentVectors: DocumentVector[]; targetDocumentVectors: DocumentVector[] } {
+    return {
+      documentVectors: this.createTfIdfWordVectors(processedDocuments, options),
+      targetDocumentVectors: this.createTfIdfWordVectors(targetProcessedDocuments, options)
+    };
+  }
+
+  /**
+   * LSA ベースの双方向学習用文書ベクトルを生成する
+   * @param processedDocuments メイン文書配列
+   * @param targetProcessedDocuments ターゲット文書配列
+   * @param options 設定オプション
+   * @returns 文書ベクトル配列
+   */
+  public createBidirectionalLsaWordVectors(
+    processedDocuments: ProcessedDocument[],
+    targetProcessedDocuments: ProcessedDocument[],
+    options: RecommenderOptions
+  ): { documentVectors: DocumentVector[]; targetDocumentVectors: DocumentVector[] } {
+    const allDocuments = processedDocuments.concat(targetProcessedDocuments);
+    const allVectors = this.createLsaWordVectors(allDocuments, options);
+    const splitIndex = processedDocuments.length;
+
+    return {
+      documentVectors: allVectors.slice(0, splitIndex),
+      targetDocumentVectors: allVectors.slice(splitIndex)
+    };
+  }
+
+  /**
+   * TF-IDFベースの文書ベクトルを生成する
+   * @param processedDocuments 前処理済み文書配列
+   * @param options 設定オプション
+   * @returns 文書ベクトル配列
+   */
+  public createTfIdfWordVectors(processedDocuments: ProcessedDocument[], options: RecommenderOptions): DocumentVector[] {
+    const tfidf = new TfIdf();
+
+    processedDocuments.forEach((processedDocument) => {
+      tfidf.addDocument(processedDocument.tokens);
+    });
+
+    const documentVectors: DocumentVector[] = [];
+
+    for (let i = 0; i < processedDocuments.length; i += 1) {
+      if (options.debug) {
+        console.log(`Creating word vector for document ${i}`);
+      }
+
+      const processedDocument = processedDocuments[i];
+      const hash: Record<string, number> = {};
+
+      const items = tfidf.listTerms(i);
+      const maxSize = Math.min(options.maxVectorSize!, items.length);
+      for (let j = 0; j < maxSize; j += 1) {
+        const item = items[j];
+        hash[item.term] = item.tfidf;
+      }
+
+      documentVectors.push({
+        id: processedDocument.id,
+        vector: new Vector(hash),
+      });
+    }
+
+    return documentVectors;
+  }
+
+  /**
+   * LSAベースの文書ベクトルを生成する
+   * @param processedDocuments 前処理済み文書配列
+   * @param options 設定オプション
+   * @returns 文書ベクトル配列
+   */
+  public createLsaWordVectors(processedDocuments: ProcessedDocument[], options: RecommenderOptions): DocumentVector[] {
+    if (processedDocuments.length === 0) {
+      return [];
+    }
+
+    const { matrix } = this.buildTfIdfMatrix(processedDocuments);
+    if (matrix.columns === 0) {
+      return this.createZeroVectors(processedDocuments);
+    }
+
+    const shouldTranspose = matrix.columns > matrix.rows;
+    const matrixForSvd = shouldTranspose ? matrix.transpose() : matrix;
+    const svd = new SingularValueDecomposition(matrixForSvd, {
+      autoTranspose: false,
+    });
+    const singularValues = svd.diagonal;
+    if (singularValues.length === 0) {
+      return this.createZeroVectors(processedDocuments);
+    }
+
+    const latentDimensions = Math.min(options.lsaDimensions!, singularValues.length);
+    const documentBasis = shouldTranspose
+      ? svd.rightSingularVectors.subMatrix(0, processedDocuments.length - 1, 0, latentDimensions - 1)
+      : svd.leftSingularVectors.subMatrix(0, processedDocuments.length - 1, 0, latentDimensions - 1);
+    const truncatedDiagonal = Matrix.diag(singularValues.slice(0, latentDimensions));
+    const reducedMatrix = documentBasis.mmul(truncatedDiagonal);
+
+    return processedDocuments.map((processedDocument, index) => {
+      const hash: Record<string, number> = {};
+
+      for (let dimensionIndex = 0; dimensionIndex < latentDimensions; dimensionIndex += 1) {
+        hash[`dim_${dimensionIndex}`] = reducedMatrix.get(index, dimensionIndex);
+      }
+
+      return {
+        id: processedDocument.id,
+        vector: new Vector(hash),
+      };
+    });
+  }
+
+  /**
+   * LSA用のTF-IDF行列を構築する
+   * @param processedDocuments 前処理済み文書配列
+   * @returns TF-IDF行列
+   */
+  private buildTfIdfMatrix(processedDocuments: ProcessedDocument[]): { matrix: Matrix; terms: string[] } {
+    const termSet = new Set<string>();
+    const termDocumentFrequency = new Map<string, number>();
+
+    processedDocuments.forEach((processedDocument) => {
+      const uniqueTerms = new Set(processedDocument.tokens);
+
+      processedDocument.tokens.forEach((token) => {
+        termSet.add(token);
+      });
+
+      uniqueTerms.forEach((term) => {
+        termDocumentFrequency.set(term, (termDocumentFrequency.get(term) ?? 0) + 1);
+      });
+    });
+
+    const terms = Array.from(termSet).sort();
+    const matrix = Matrix.zeros(processedDocuments.length, terms.length);
+    const totalDocuments = processedDocuments.length;
+
+    processedDocuments.forEach((processedDocument, rowIndex) => {
+      const termFrequency = processedDocument.tokens.reduce((acc: Record<string, number>, token) => {
+        acc[token] = (acc[token] ?? 0) + 1;
+        return acc;
+      }, {});
+
+      terms.forEach((term, columnIndex) => {
+        const tf = termFrequency[term] ?? 0;
+        if (tf === 0) {
+          return;
+        }
+
+        const documentFrequency = termDocumentFrequency.get(term) ?? 0;
+        const idf = Math.log((1 + totalDocuments) / (1 + documentFrequency)) + 1;
+        matrix.set(rowIndex, columnIndex, tf * idf);
+      });
+    });
+
+    return { matrix, terms };
+  }
+
+  /**
+   * ゼロベクトルの文書ベクトル配列を生成する
+   * @param processedDocuments 前処理済み文書配列
+   * @returns 文書ベクトル配列
+   */
+  private createZeroVectors(processedDocuments: ProcessedDocument[]): DocumentVector[] {
+    return processedDocuments.map((processedDocument) => ({
+      id: processedDocument.id,
+      vector: new Vector({}),
+    }));
+  }
+}

--- a/src/lib/factories/ProcessingPipelineFactory.ts
+++ b/src/lib/factories/ProcessingPipelineFactory.ts
@@ -35,16 +35,18 @@ export class ProcessingPipelineFactory {
     language: 'en' | 'ja' = 'en',
     filterOptions: TokenFilterOptions = {}
   ): ProcessingPipeline {
-    if (language === 'ja') {
-      return {
-        tokenizer: new JapaneseTokenizer(),
-        filter: new JapaneseTokenFilter(filterOptions)
-      };
-    } else {
-      return {
-        tokenizer: new EnglishTokenizer(),
-        filter: new EnglishTokenFilter(filterOptions)
-      };
+    switch (language) {
+      case 'ja':
+        return {
+          tokenizer: this.createTokenizer('ja'),
+          filter: new JapaneseTokenFilter(filterOptions),
+        };
+      case 'en':
+      default:
+        return {
+          tokenizer: this.createTokenizer('en'),
+          filter: new EnglishTokenFilter(filterOptions),
+        };
     }
   }
 }

--- a/src/lib/factories/TrainingStrategyFactory.ts
+++ b/src/lib/factories/TrainingStrategyFactory.ts
@@ -1,0 +1,159 @@
+import { RecommenderOptions } from '../../types/index.js';
+import { Bm25SimilarityService } from '../services/Bm25SimilarityService.js';
+import { DocumentPreprocessor } from '../services/DocumentPreprocessor.js';
+import { DocumentVectorFactory } from './DocumentVectorFactory.js';
+import { SimilarityCalculator } from '../services/SimilarityCalculator.js';
+import { SimilarityResultBuilder } from '../services/SimilarityResultBuilder.js';
+import {
+  Bm25TrainingStrategy,
+  bm25TrainingStrategyMetadata,
+} from '../strategies/Bm25TrainingStrategy.js';
+import {
+  LsaTrainingStrategy,
+  lsaTrainingStrategyMetadata,
+} from '../strategies/LsaTrainingStrategy.js';
+import {
+  RecommenderTrainingStrategy,
+  RecommenderTrainingStrategyMetadata,
+} from '../strategies/RecommenderTrainingStrategy.js';
+import {
+  TfidfTrainingStrategy,
+  tfidfTrainingStrategyMetadata,
+} from '../strategies/TfidfTrainingStrategy.js';
+
+type SupportedAlgorithm = 'tfidf' | 'lsa' | 'bm25';
+
+/**
+ * ベクトル系 strategy の依存セット
+ */
+interface VectorTrainingDependencies {
+  /** 文書前処理サービス */
+  documentPreprocessor: DocumentPreprocessor;
+  /** 文書ベクトル生成サービス */
+  documentVectorFactory: DocumentVectorFactory;
+  /** 類似度計算サービス */
+  similarityCalculator: SimilarityCalculator;
+}
+
+/**
+ * BM25 strategy の依存セット
+ */
+interface Bm25TrainingDependencies {
+  /** 文書前処理サービス */
+  documentPreprocessor: DocumentPreprocessor;
+  /** BM25 類似度計算サービス */
+  bm25SimilarityService: Bm25SimilarityService;
+}
+
+/**
+ * 学習戦略メタデータマップ
+ */
+const strategyMetadataMap: Record<SupportedAlgorithm, RecommenderTrainingStrategyMetadata> = {
+  tfidf: tfidfTrainingStrategyMetadata,
+  lsa: lsaTrainingStrategyMetadata,
+  bm25: bm25TrainingStrategyMetadata,
+};
+
+/**
+ * 学習戦略ファクトリー
+ */
+export class TrainingStrategyFactory {
+  /**
+   * アルゴリズムに対応する学習戦略を取得する
+   * @param algorithm 推薦アルゴリズム
+   * @returns 学習戦略
+   */
+  public static create(algorithm: RecommenderOptions['algorithm'] = 'tfidf'): RecommenderTrainingStrategy {
+    const resolvedAlgorithm = (algorithm ?? 'tfidf') as SupportedAlgorithm;
+
+    switch (resolvedAlgorithm) {
+      case 'lsa':
+        return this.createLsaStrategy();
+      case 'bm25':
+        return this.createBm25Strategy();
+      case 'tfidf':
+      default:
+        return this.createTfidfStrategy();
+    }
+  }
+
+  /**
+   * アルゴリズムに対応する学習戦略メタデータを取得する
+   * @param algorithm 推薦アルゴリズム
+   * @returns 学習戦略メタデータ
+   */
+  public static getMetadata(
+    algorithm: RecommenderOptions['algorithm'] = 'tfidf'
+  ): RecommenderTrainingStrategyMetadata {
+    const resolvedAlgorithm = (algorithm ?? 'tfidf') as SupportedAlgorithm;
+    return strategyMetadataMap[resolvedAlgorithm];
+  }
+
+  /**
+   * TF-IDF 学習戦略を生成する
+   * @returns TF-IDF 学習戦略
+   */
+  private static createTfidfStrategy(): RecommenderTrainingStrategy {
+    const dependencies = this.createVectorTrainingDependencies();
+
+    return new TfidfTrainingStrategy(
+      dependencies.documentPreprocessor,
+      dependencies.documentVectorFactory,
+      dependencies.similarityCalculator
+    );
+  }
+
+  /**
+   * LSA 学習戦略を生成する
+   * @returns LSA 学習戦略
+   */
+  private static createLsaStrategy(): RecommenderTrainingStrategy {
+    const dependencies = this.createVectorTrainingDependencies();
+
+    return new LsaTrainingStrategy(
+      dependencies.documentPreprocessor,
+      dependencies.documentVectorFactory,
+      dependencies.similarityCalculator
+    );
+  }
+
+  /**
+   * BM25 学習戦略を生成する
+   * @returns BM25 学習戦略
+   */
+  private static createBm25Strategy(): RecommenderTrainingStrategy {
+    const dependencies = this.createBm25TrainingDependencies();
+
+    return new Bm25TrainingStrategy(
+      dependencies.documentPreprocessor,
+      dependencies.bm25SimilarityService
+    );
+  }
+
+  /**
+   * ベクトル系 strategy 用の依存を生成する
+   * @returns ベクトル系依存セット
+   */
+  private static createVectorTrainingDependencies(): VectorTrainingDependencies {
+    const similarityResultBuilder = new SimilarityResultBuilder();
+
+    return {
+      documentPreprocessor: new DocumentPreprocessor(),
+      documentVectorFactory: new DocumentVectorFactory(),
+      similarityCalculator: new SimilarityCalculator(similarityResultBuilder),
+    };
+  }
+
+  /**
+   * BM25 strategy 用の依存を生成する
+   * @returns BM25 依存セット
+   */
+  private static createBm25TrainingDependencies(): Bm25TrainingDependencies {
+    const similarityResultBuilder = new SimilarityResultBuilder();
+
+    return {
+      documentPreprocessor: new DocumentPreprocessor(),
+      bm25SimilarityService: new Bm25SimilarityService(similarityResultBuilder),
+    };
+  }
+}

--- a/src/lib/filters/EnglishTokenFilter.ts
+++ b/src/lib/filters/EnglishTokenFilter.ts
@@ -25,7 +25,7 @@ export class EnglishTokenFilter implements IEnglishTokenFilter {
       removeStopwords: options.removeStopwords ?? true,
       customStopWords: options.customStopWords ?? [],
       minTokenLength: options.minTokenLength ?? 1,
-      allowedPos: options.allowedPos ?? ['名詞', '動詞', '形容詞'] // 日本語用なので英語では使用しない
+      allowedPos: options.allowedPos ?? [] // 英語フィルターでは使用しない
     };
   }
 

--- a/src/lib/services/Bm25SimilarityService.ts
+++ b/src/lib/services/Bm25SimilarityService.ts
@@ -1,0 +1,210 @@
+import MiniSearch from 'minisearch';
+import {
+  ProcessedDocument,
+  RecommenderOptions,
+  SimilarDocument,
+} from '../../types/index.js';
+import { SimilarityResultBuilder } from './SimilarityResultBuilder.js';
+
+/**
+ * BM25索引用の文書インターフェース
+ */
+interface Bm25SearchDocument {
+  /** 文書ID */
+  id: string;
+  /** 本文の検索用文字列 */
+  content: string;
+  /** タイトルの検索用文字列 */
+  title?: string;
+}
+
+/**
+ * BM25検索結果の最小インターフェース
+ */
+interface Bm25SearchResult {
+  /** 文書ID */
+  id: string;
+  /** BM25スコア */
+  score: number;
+}
+
+/**
+ * BM25類似度計算サービス
+ */
+export class Bm25SimilarityService {
+  /** 類似度結果構築サービス */
+  private similarityResultBuilder: SimilarityResultBuilder;
+
+  /**
+   * コンストラクタ
+   * @param similarityResultBuilder 類似度結果構築サービス
+   */
+  constructor(similarityResultBuilder: SimilarityResultBuilder = new SimilarityResultBuilder()) {
+    this.similarityResultBuilder = similarityResultBuilder;
+  }
+
+  /**
+   * 同一コレクション向けのBM25類似度を計算する
+   * @param processedDocuments 前処理済み文書配列
+   * @param options 設定オプション
+   * @returns 類似度データ
+   */
+  public calculate(
+    processedDocuments: ProcessedDocument[],
+    options: RecommenderOptions
+  ): Record<string, SimilarDocument[]> {
+    const data = this.similarityResultBuilder.initializeDataHash(processedDocuments);
+    const bm25Index = this.createBm25Index(processedDocuments);
+
+    processedDocuments.forEach((processedDocument, index) => {
+      if (options.debug) {
+        console.log(`Calculating BM25 score for document ${index}`);
+      }
+
+      data[processedDocument.id] = this.searchBm25Index(bm25Index, processedDocument, processedDocument.id, options);
+    });
+
+    this.similarityResultBuilder.orderDocuments(data, options);
+
+    return data;
+  }
+
+  /**
+   * 双方向学習向けのBM25類似度を計算する
+   * @param processedDocuments メイン文書配列
+   * @param targetProcessedDocuments ターゲット文書配列
+   * @param options 設定オプション
+   * @returns 類似度データ
+   */
+  public calculateBetweenCollections(
+    processedDocuments: ProcessedDocument[],
+    targetProcessedDocuments: ProcessedDocument[],
+    options: RecommenderOptions
+  ): Record<string, SimilarDocument[]> {
+    const data = {
+      ...this.similarityResultBuilder.initializeDataHash(processedDocuments),
+      ...this.similarityResultBuilder.initializeDataHash(targetProcessedDocuments)
+    };
+    const documentIndex = this.createBm25Index(processedDocuments);
+    const targetDocumentIndex = this.createBm25Index(targetProcessedDocuments);
+
+    processedDocuments.forEach((processedDocument, index) => {
+      if (options.debug) {
+        console.log(`Calculating BM25 score for source document ${index}`);
+      }
+
+      data[processedDocument.id] = this.searchBm25Index(
+        targetDocumentIndex,
+        processedDocument,
+        processedDocument.id,
+        options
+      );
+    });
+
+    targetProcessedDocuments.forEach((processedDocument, index) => {
+      if (options.debug) {
+        console.log(`Calculating BM25 score for target document ${index}`);
+      }
+
+      data[processedDocument.id] = this.searchBm25Index(
+        documentIndex,
+        processedDocument,
+        processedDocument.id,
+        options
+      );
+    });
+
+    this.similarityResultBuilder.orderDocuments(data, options);
+
+    return data;
+  }
+
+  /**
+   * BM25用のインデックスを生成する
+   * @param processedDocuments 前処理済み文書配列
+   * @returns MiniSearchインデックス
+   */
+  private createBm25Index(processedDocuments: ProcessedDocument[]): MiniSearch<Bm25SearchDocument> {
+    const miniSearch = new MiniSearch<Bm25SearchDocument>({
+      fields: ['title', 'content'],
+    });
+    const searchDocuments = this.createBm25SearchDocuments(processedDocuments);
+
+    if (searchDocuments.length > 0) {
+      miniSearch.addAll(searchDocuments);
+    }
+
+    return miniSearch;
+  }
+
+  /**
+   * BM25用の索引文書配列を生成する
+   * @param processedDocuments 前処理済み文書配列
+   * @returns 索引用文書配列
+   */
+  private createBm25SearchDocuments(processedDocuments: ProcessedDocument[]): Bm25SearchDocument[] {
+    return processedDocuments.map((processedDocument) => {
+      const title = this.joinBm25Tokens(processedDocument.titleTokens ?? []);
+
+      return {
+        id: processedDocument.id,
+        content: this.joinBm25Tokens(processedDocument.tokens),
+        ...(title ? { title } : {})
+      };
+    });
+  }
+
+  /**
+   * BM25インデックスを検索する
+   * @param bm25Index MiniSearchインデックス
+   * @param processedDocument 検索元文書
+   * @param sourceDocumentId 除外対象の文書ID
+   * @param options 設定オプション
+   * @returns 類似文書配列
+   */
+  private searchBm25Index(
+    bm25Index: MiniSearch<Bm25SearchDocument>,
+    processedDocument: ProcessedDocument,
+    sourceDocumentId: string,
+    options: RecommenderOptions
+  ): SimilarDocument[] {
+    const query = this.buildBm25Query(processedDocument);
+    if (!query) {
+      return [];
+    }
+
+    const results = bm25Index.search(query) as Bm25SearchResult[];
+
+    return results
+      .filter((result) => result.id !== sourceDocumentId)
+      .filter((result) => Number.isFinite(result.score) && result.score > options.minScore!)
+      .map((result) => ({
+        id: result.id,
+        score: result.score,
+      }))
+      .slice(0, options.maxSimilarDocuments);
+  }
+
+  /**
+   * BM25検索クエリを構築する
+   * @param processedDocument 前処理済み文書
+   * @returns 検索クエリ文字列
+   */
+  private buildBm25Query(processedDocument: ProcessedDocument): string {
+    const queryTokens = [
+      ...(processedDocument.titleTokens ?? []),
+      ...processedDocument.tokens,
+    ];
+
+    return this.joinBm25Tokens(queryTokens);
+  }
+
+  /**
+   * BM25用にトークン配列を結合する
+   * @param tokens トークン配列
+   * @returns スペース結合済み文字列
+   */
+  private joinBm25Tokens(tokens: string[]): string {
+    return tokens.join(' ').trim();
+  }
+}

--- a/src/lib/services/DocumentPreprocessor.ts
+++ b/src/lib/services/DocumentPreprocessor.ts
@@ -1,0 +1,116 @@
+import {
+  Document,
+  ProcessedDocument,
+  ProcessingPipeline,
+  RecommenderOptions,
+} from '../../types/index.js';
+import { JapaneseTokenizer } from '../tokenizers/JapaneseTokenizer.js';
+import { EnglishTokenFilter } from '../filters/EnglishTokenFilter.js';
+import { JapaneseTokenFilter } from '../filters/JapaneseTokenFilter.js';
+
+/**
+ * 文書前処理サービス
+ * トークン化とフィルタリングを担当します
+ */
+export class DocumentPreprocessor {
+  /**
+   * 文書配列を前処理する
+   * @param documents 対象文書配列
+   * @param pipeline 処理パイプライン
+   * @param options 推薦設定
+   * @returns 前処理済み文書配列
+   */
+  public async preprocessDocuments(
+    documents: Document[],
+    pipeline: ProcessingPipeline,
+    options: RecommenderOptions
+  ): Promise<ProcessedDocument[]> {
+    if (options.debug) {
+      console.log('Preprocessing documents');
+    }
+
+    if (options.language === 'ja') {
+      const processedDocuments: ProcessedDocument[] = [];
+
+      for (const document of documents) {
+        processedDocuments.push(await this.preprocessDocument(document, pipeline, options));
+      }
+
+      return processedDocuments;
+    }
+
+    return Promise.all(documents.map((document) => this.preprocessDocument(document, pipeline, options)));
+  }
+
+  /**
+   * 単一文書を前処理する
+   * @param document 対象文書
+   * @param pipeline 処理パイプライン
+   * @param options 推薦設定
+   * @returns 前処理済み文書
+   */
+  private async preprocessDocument(
+    document: Document,
+    pipeline: ProcessingPipeline,
+    options: RecommenderOptions
+  ): Promise<ProcessedDocument> {
+    const title = (typeof document.title === 'string' && document.title.trim().length > 0)
+      ? document.title
+      : undefined;
+
+    if (options.language === 'ja') {
+      const tokens = await this.getTokensFromString(document.content, pipeline, options);
+      const titleTokens = title
+        ? await this.getTokensFromString(title, pipeline, options)
+        : undefined;
+
+      return {
+        id: document.id,
+        tokens,
+        titleTokens,
+        originalDocument: document,
+      };
+    }
+
+    const [tokens, titleTokens] = await Promise.all([
+      this.getTokensFromString(document.content, pipeline, options),
+      title ? this.getTokensFromString(title, pipeline, options) : Promise.resolve(undefined)
+    ]);
+
+    return {
+      id: document.id,
+      tokens,
+      titleTokens,
+      originalDocument: document,
+    };
+  }
+
+  /**
+   * 文字列からトークンを抽出する
+   * @param string 対象文字列
+   * @param pipeline 処理パイプライン
+   * @param options 推薦設定
+   * @returns トークン配列
+   */
+  private async getTokensFromString(
+    string: string,
+    pipeline: ProcessingPipeline,
+    options: RecommenderOptions
+  ): Promise<string[]> {
+    if (options.language === 'ja') {
+      const japaneseTokenizer = pipeline.tokenizer as JapaneseTokenizer;
+      const japaneseFilter = pipeline.filter as JapaneseTokenFilter;
+      const detailedTokens = await japaneseTokenizer.getDetailedJapaneseTokens(string);
+      return japaneseFilter.filterWithPos(detailedTokens);
+    }
+
+    const rawTokens = await pipeline.tokenizer.tokenize(string);
+
+    if (options.language === 'en') {
+      const englishFilter = pipeline.filter as EnglishTokenFilter;
+      return englishFilter.filterWithNgrams(rawTokens);
+    }
+
+    return pipeline.filter.filter(rawTokens);
+  }
+}

--- a/src/lib/services/RecommenderOptionsResolver.ts
+++ b/src/lib/services/RecommenderOptionsResolver.ts
@@ -1,0 +1,65 @@
+import {
+  RecommenderOptions,
+  TokenFilterOptions,
+} from '../../types/index.js';
+import { TrainingStrategyFactory } from '../factories/TrainingStrategyFactory.js';
+
+/**
+ * デフォルト設定オプション
+ */
+export const defaultRecommenderOptions: RecommenderOptions = {
+  maxVectorSize: 100,
+  maxSimilarDocuments: Number.MAX_SAFE_INTEGER,
+  minScore: 0,
+  debug: false,
+  algorithm: 'tfidf',
+  language: 'en',
+  lsaDimensions: 12,
+  tokenFilterOptions: {
+    removeDuplicates: true,
+    removeStopwords: true,
+    customStopWords: [],
+    minTokenLength: 1,
+    allowedPos: ['名詞', '動詞', '形容詞']
+  }
+};
+
+/**
+ * 推薦設定の解決を担当するクラス
+ */
+export class RecommenderOptionsResolver {
+  /**
+   * 設定オプションを解決する
+   * @param options 指定オプション
+   * @returns 解決済みオプション
+   */
+  public static resolveOptions(options: RecommenderOptions): RecommenderOptions {
+    const algorithm = options.algorithm ?? defaultRecommenderOptions.algorithm;
+    const strategyMetadata = TrainingStrategyFactory.getMetadata(algorithm);
+
+    return Object.assign({}, defaultRecommenderOptions, strategyMetadata.optionDefaults, options, {
+      tokenFilterOptions: this.resolveTokenFilterOptions(
+        options.tokenFilterOptions,
+        strategyMetadata.tokenFilterOptionsDefaults
+      ),
+    });
+  }
+
+  /**
+   * トークンフィルターの設定を解決する
+   * @param tokenFilterOptions 指定オプション
+   * @param algorithm 推薦アルゴリズム
+   * @returns 解決済みフィルターオプション
+   */
+  private static resolveTokenFilterOptions(
+    tokenFilterOptions: TokenFilterOptions = {},
+    strategyTokenFilterDefaults: TokenFilterOptions = {}
+  ): TokenFilterOptions {
+    return Object.assign(
+      {},
+      defaultRecommenderOptions.tokenFilterOptions,
+      strategyTokenFilterDefaults,
+      tokenFilterOptions
+    );
+  }
+}

--- a/src/lib/services/RecommenderValidator.ts
+++ b/src/lib/services/RecommenderValidator.ts
@@ -1,0 +1,71 @@
+import {
+  Document,
+  RecommenderOptions,
+} from '../../types/index.js';
+
+/**
+ * 推薦入力の検証を担当するクラス
+ */
+export class RecommenderValidator {
+  /**
+   * 設定オプションを検証する
+   * @param options 設定オプション
+   * @throws {Error} 無効なオプションが指定された場合
+   */
+  public static validateOptions(options: RecommenderOptions = {}): void {
+    if ((options.maxVectorSize !== undefined) &&
+      (!Number.isInteger(options.maxVectorSize) || options.maxVectorSize <= 0)) {
+      throw new Error('The option maxVectorSize should be integer and greater than 0');
+    }
+
+    if ((options.maxSimilarDocuments !== undefined) &&
+      (!Number.isInteger(options.maxSimilarDocuments) || options.maxSimilarDocuments <= 0)) {
+      throw new Error('The option maxSimilarDocuments should be integer and greater than 0');
+    }
+
+    if ((options.minScore !== undefined) &&
+      (typeof options.minScore !== 'number' || options.minScore < 0 || options.minScore > 1)) {
+      throw new Error('The option minScore should be a number between 0 and 1');
+    }
+
+    if ((options.algorithm !== undefined) &&
+      (typeof options.algorithm !== 'string' || !['tfidf', 'lsa', 'bm25'].includes(options.algorithm))) {
+      throw new Error('The option algorithm should be either "tfidf", "lsa" or "bm25"');
+    }
+
+    if ((options.language !== undefined) &&
+      (typeof options.language !== 'string' || !['en', 'ja'].includes(options.language))) {
+      throw new Error('The option language should be either "en" or "ja"');
+    }
+
+    if ((options.lsaDimensions !== undefined) &&
+      (!Number.isInteger(options.lsaDimensions) || options.lsaDimensions <= 0)) {
+      throw new Error('The option lsaDimensions should be integer and greater than 0');
+    }
+  }
+
+  /**
+   * 文書配列を検証する
+   * @param documents 検証対象の文書配列
+   * @throws {Error} 無効な文書配列が指定された場合
+   */
+  public static validateDocuments(documents: Document[]): void {
+    if (!Array.isArray(documents)) {
+      throw new Error('Documents should be an array of objects');
+    }
+
+    for (let i = 0; i < documents.length; i += 1) {
+      const document = documents[i];
+
+      if (!Object.prototype.hasOwnProperty.call(document, 'id') ||
+          !Object.prototype.hasOwnProperty.call(document, 'content')) {
+        throw new Error('Documents should be have fields id and content');
+      }
+
+      if (Object.prototype.hasOwnProperty.call(document, 'tokens') ||
+          Object.prototype.hasOwnProperty.call(document, 'vector')) {
+        throw new Error('"tokens" and "vector" properties are reserved and cannot be used as document properties');
+      }
+    }
+  }
+}

--- a/src/lib/services/SimilarityCalculator.ts
+++ b/src/lib/services/SimilarityCalculator.ts
@@ -1,0 +1,133 @@
+import Vector from 'vector-object';
+import {
+  RecommenderOptions,
+  SimilarDocument,
+} from '../../types/index.js';
+import { SimilarityResultBuilder } from './SimilarityResultBuilder.js';
+
+/**
+ * 文書ベクトルインターフェース
+ */
+export interface DocumentVector {
+  /** 文書ID */
+  id: string;
+  /** ベクトルオブジェクト */
+  vector: Vector;
+}
+
+/**
+ * ベクトル類似度計算サービス
+ */
+export class SimilarityCalculator {
+  /** 類似度結果構築サービス */
+  private similarityResultBuilder: SimilarityResultBuilder;
+
+  /**
+   * コンストラクタ
+   * @param similarityResultBuilder 類似度結果構築サービス
+   */
+  constructor(similarityResultBuilder: SimilarityResultBuilder = new SimilarityResultBuilder()) {
+    this.similarityResultBuilder = similarityResultBuilder;
+  }
+
+  /**
+   * 2つのベクトル集合の類似度を計算する
+   * @param documentVectors メイン文書ベクトル
+   * @param targetDocumentVectors ターゲット文書ベクトル
+   * @param options 設定オプション
+   * @returns 類似度データ
+   */
+  public calculateBetweenTwoVectors(
+    documentVectors: DocumentVector[],
+    targetDocumentVectors: DocumentVector[],
+    options: RecommenderOptions
+  ): Record<string, SimilarDocument[]> {
+    const data = {
+      ...this.similarityResultBuilder.initializeDataHash(documentVectors),
+      ...this.similarityResultBuilder.initializeDataHash(targetDocumentVectors)
+    };
+
+    for (let i = 0; i < documentVectors.length; i += 1) {
+      if (options.debug) console.log(`Calculating similarity score for document ${i}`);
+
+      for (let j = 0; j < targetDocumentVectors.length; j += 1) {
+        const documentVectorA = documentVectors[i];
+        const documentVectorB = targetDocumentVectors[j];
+        const idi = documentVectorA.id;
+        const vi = documentVectorA.vector;
+        const idj = documentVectorB.id;
+        const vj = documentVectorB.vector;
+        const similarity = this.getCosineSimilarity(vi, vj);
+
+        if (similarity > options.minScore!) {
+          data[idi].push({
+            id: documentVectorB.id,
+            score: similarity
+          });
+          data[idj].push({
+            id: documentVectorA.id,
+            score: similarity
+          });
+        }
+      }
+    }
+
+    this.similarityResultBuilder.orderDocuments(data, options);
+
+    return data;
+  }
+
+  /**
+   * 同一コレクション内の類似度を計算する
+   * @param documentVectors 文書ベクトル配列
+   * @param options 設定オプション
+   * @returns 類似度データ
+   */
+  public calculate(
+    documentVectors: DocumentVector[],
+    options: RecommenderOptions
+  ): Record<string, SimilarDocument[]> {
+    const data = { ...this.similarityResultBuilder.initializeDataHash(documentVectors) };
+
+    for (let i = 0; i < documentVectors.length; i += 1) {
+      if (options.debug) console.log(`Calculating similarity score for document ${i}`);
+
+      for (let j = 0; j < i; j += 1) {
+        const documentVectorA = documentVectors[i];
+        const idi = documentVectorA.id;
+        const vi = documentVectorA.vector;
+        const documentVectorB = documentVectors[j];
+        const idj = documentVectorB.id;
+        const vj = documentVectorB.vector;
+        const similarity = this.getCosineSimilarity(vi, vj);
+
+        if (similarity > options.minScore!) {
+          data[idi].push({
+            id: documentVectorB.id,
+            score: similarity
+          });
+
+          data[idj].push({
+            id: documentVectorA.id,
+            score: similarity
+          });
+        }
+      }
+    }
+
+    this.similarityResultBuilder.orderDocuments(data, options);
+
+    return data;
+  }
+
+  /**
+   * コサイン類似度を安全に取得する
+   * @param vectorA ベクトルA
+   * @param vectorB ベクトルB
+   * @returns コサイン類似度
+   */
+  public getCosineSimilarity(vectorA: Vector, vectorB: Vector): number {
+    const similarity = vectorA.getCosineSimilarity(vectorB);
+    return Number.isFinite(similarity) ? similarity : 0;
+  }
+}

--- a/src/lib/services/SimilarityResultBuilder.ts
+++ b/src/lib/services/SimilarityResultBuilder.ts
@@ -1,0 +1,37 @@
+import {
+  RecommenderOptions,
+  SimilarDocument,
+} from '../../types/index.js';
+
+/**
+ * 類似度結果データの構築を担当するサービス
+ */
+export class SimilarityResultBuilder {
+  /**
+   * データハッシュを初期化する
+   * @param items 文書配列
+   * @returns 初期化済みデータハッシュ
+   */
+  public initializeDataHash<T extends { id: string }>(items: T[]): Record<string, SimilarDocument[]> {
+    return items.reduce((acc: Record<string, SimilarDocument[]>, item) => {
+      acc[item.id] = [];
+      return acc;
+    }, {});
+  }
+
+  /**
+   * 類似文書を降順でソートし、最大数を制限する
+   * @param data 類似度データ
+   * @param options 設定オプション
+   */
+  public orderDocuments(data: Record<string, SimilarDocument[]>, options: RecommenderOptions): void {
+    Object.keys(data)
+      .forEach((id) => {
+        data[id].sort((a, b) => b.score - a.score);
+
+        if (data[id].length > options.maxSimilarDocuments!) {
+          data[id] = data[id].slice(0, options.maxSimilarDocuments);
+        }
+      });
+  }
+}

--- a/src/lib/strategies/AbstractTrainingStrategy.ts
+++ b/src/lib/strategies/AbstractTrainingStrategy.ts
@@ -1,0 +1,103 @@
+import {
+  Document,
+  ProcessedDocument,
+  SimilarDocument,
+} from '../../types/index.js';
+import { DocumentPreprocessor } from '../services/DocumentPreprocessor.js';
+import {
+  RecommenderTrainingContext,
+  RecommenderTrainingStrategy,
+} from './RecommenderTrainingStrategy.js';
+
+/**
+ * 学習戦略の共通基底クラス
+ */
+export abstract class AbstractTrainingStrategy implements RecommenderTrainingStrategy {
+  /** 文書前処理サービス */
+  protected documentPreprocessor: DocumentPreprocessor;
+
+  /**
+   * コンストラクタ
+   * @param documentPreprocessor 文書前処理サービス
+   */
+  constructor(documentPreprocessor: DocumentPreprocessor = new DocumentPreprocessor()) {
+    this.documentPreprocessor = documentPreprocessor;
+  }
+
+  /**
+   * 単一コレクションの学習を実行する
+   * @param documents 学習対象の文書配列
+   * @param context 学習コンテキスト
+   * @returns 類似度データ
+   */
+  public abstract train(
+    documents: Document[],
+    context: RecommenderTrainingContext
+  ): Promise<Record<string, SimilarDocument[]>>;
+
+  /**
+   * 双方向学習を実行する
+   * @param documents メインの文書配列
+   * @param targetDocuments ターゲット文書配列
+   * @param context 学習コンテキスト
+   * @returns 類似度データ
+   */
+  public abstract trainBidirectional(
+    documents: Document[],
+    targetDocuments: Document[],
+    context: RecommenderTrainingContext
+  ): Promise<Record<string, SimilarDocument[]>>;
+
+  /**
+   * 対象文書数をデバッグ出力する
+   * @param documents 学習対象の文書配列
+   * @param context 学習コンテキスト
+   */
+  protected logTotalDocuments(documents: Document[], context: RecommenderTrainingContext): void {
+    if (context.options.debug) {
+      console.log(`Total documents: ${documents.length}`);
+    }
+  }
+
+  /**
+   * 単一コレクションの前処理を実行する
+   * @param documents 学習対象の文書配列
+   * @param context 学習コンテキスト
+   * @returns 前処理済み文書配列
+   */
+  protected async preprocessDocuments(
+    documents: Document[],
+    context: RecommenderTrainingContext
+  ): Promise<ProcessedDocument[]> {
+    return this.documentPreprocessor.preprocessDocuments(documents, context.pipeline, context.options);
+  }
+
+  /**
+   * 双方向学習用の前処理を実行する
+   * @param documents メインの文書配列
+   * @param targetDocuments ターゲット文書配列
+   * @param context 学習コンテキスト
+   * @returns 前処理済み文書
+   */
+  protected async preprocessBidirectionalDocuments(
+    documents: Document[],
+    targetDocuments: Document[],
+    context: RecommenderTrainingContext
+  ): Promise<{ processedDocuments: ProcessedDocument[]; targetProcessedDocuments: ProcessedDocument[] }> {
+    const processedDocuments = await this.documentPreprocessor.preprocessDocuments(
+      documents,
+      context.pipeline,
+      context.options
+    );
+    const targetProcessedDocuments = await this.documentPreprocessor.preprocessDocuments(
+      targetDocuments,
+      context.pipeline,
+      context.options
+    );
+
+    return {
+      processedDocuments,
+      targetProcessedDocuments,
+    };
+  }
+}

--- a/src/lib/strategies/AbstractVectorTrainingStrategy.ts
+++ b/src/lib/strategies/AbstractVectorTrainingStrategy.ts
@@ -1,0 +1,114 @@
+import {
+  Document,
+  ProcessedDocument,
+  SimilarDocument,
+} from '../../types/index.js';
+import { DocumentVectorFactory } from '../factories/DocumentVectorFactory.js';
+import {
+  DocumentVector,
+  SimilarityCalculator,
+} from '../services/SimilarityCalculator.js';
+import { DocumentPreprocessor } from '../services/DocumentPreprocessor.js';
+import { AbstractTrainingStrategy } from './AbstractTrainingStrategy.js';
+import { RecommenderTrainingContext } from './RecommenderTrainingStrategy.js';
+
+/**
+ * ベクトル系学習戦略の共通基底クラス
+ */
+export abstract class AbstractVectorTrainingStrategy extends AbstractTrainingStrategy {
+  /** 類似度計算サービス */
+  private similarityCalculator: SimilarityCalculator;
+
+  /** 文書ベクトル生成サービス */
+  protected documentVectorFactory: DocumentVectorFactory;
+
+  /**
+   * コンストラクタ
+   * @param documentPreprocessor 文書前処理サービス
+   * @param documentVectorFactory 文書ベクトル生成サービス
+   * @param similarityCalculator 類似度計算サービス
+   */
+  constructor(
+    documentPreprocessor: DocumentPreprocessor = new DocumentPreprocessor(),
+    documentVectorFactory: DocumentVectorFactory = new DocumentVectorFactory(),
+    similarityCalculator: SimilarityCalculator = new SimilarityCalculator()
+  ) {
+    super(documentPreprocessor);
+    this.documentVectorFactory = documentVectorFactory;
+    this.similarityCalculator = similarityCalculator;
+  }
+
+  /**
+   * 単一コレクションの学習を実行する
+   * @param documents 学習対象の文書配列
+   * @param context 学習コンテキスト
+   * @returns 類似度データ
+   */
+  public async train(
+    documents: Document[],
+    context: RecommenderTrainingContext
+  ): Promise<Record<string, SimilarDocument[]>> {
+    this.logTotalDocuments(documents, context);
+
+    const processedDocuments = await this.preprocessDocuments(documents, context);
+    const documentVectors = this.createDocumentVectors(processedDocuments, context);
+
+    return this.similarityCalculator.calculate(documentVectors, context.options);
+  }
+
+  /**
+   * 双方向学習を実行する
+   * @param documents メインの文書配列
+   * @param targetDocuments ターゲット文書配列
+   * @param context 学習コンテキスト
+   * @returns 類似度データ
+   */
+  public async trainBidirectional(
+    documents: Document[],
+    targetDocuments: Document[],
+    context: RecommenderTrainingContext
+  ): Promise<Record<string, SimilarDocument[]>> {
+    this.logTotalDocuments(documents, context);
+
+    const { processedDocuments, targetProcessedDocuments } = await this.preprocessBidirectionalDocuments(
+      documents,
+      targetDocuments,
+      context
+    );
+    const { documentVectors, targetDocumentVectors } = this.createBidirectionalDocumentVectors(
+      processedDocuments,
+      targetProcessedDocuments,
+      context
+    );
+
+    return this.similarityCalculator.calculateBetweenTwoVectors(
+      documentVectors,
+      targetDocumentVectors,
+      context.options
+    );
+  }
+
+  /**
+   * 単一コレクション用の文書ベクトルを生成する
+   * @param processedDocuments 前処理済み文書配列
+   * @param context 学習コンテキスト
+   * @returns 文書ベクトル配列
+   */
+  protected abstract createDocumentVectors(
+    processedDocuments: ProcessedDocument[],
+    context: RecommenderTrainingContext
+  ): DocumentVector[];
+
+  /**
+   * 双方向学習用の文書ベクトルを生成する
+   * @param processedDocuments メイン文書配列
+   * @param targetProcessedDocuments ターゲット文書配列
+   * @param context 学習コンテキスト
+   * @returns 文書ベクトル配列
+   */
+  protected abstract createBidirectionalDocumentVectors(
+    processedDocuments: ProcessedDocument[],
+    targetProcessedDocuments: ProcessedDocument[],
+    context: RecommenderTrainingContext
+  ): { documentVectors: DocumentVector[]; targetDocumentVectors: DocumentVector[] };
+}

--- a/src/lib/strategies/Bm25TrainingStrategy.ts
+++ b/src/lib/strategies/Bm25TrainingStrategy.ts
@@ -1,0 +1,82 @@
+import {
+  Document,
+  SimilarDocument,
+} from '../../types/index.js';
+import { Bm25SimilarityService } from '../services/Bm25SimilarityService.js';
+import { DocumentPreprocessor } from '../services/DocumentPreprocessor.js';
+import { AbstractTrainingStrategy } from './AbstractTrainingStrategy.js';
+import {
+  RecommenderTrainingContext,
+  RecommenderTrainingStrategyMetadata,
+} from './RecommenderTrainingStrategy.js';
+
+/** BM25 学習戦略メタデータ */
+export const bm25TrainingStrategyMetadata: RecommenderTrainingStrategyMetadata = {
+  tokenFilterOptionsDefaults: {
+    removeDuplicates: false,
+  }
+};
+
+/**
+ * BM25 学習戦略
+ */
+export class Bm25TrainingStrategy extends AbstractTrainingStrategy {
+  /** BM25 類似度計算サービス */
+  private bm25SimilarityService: Bm25SimilarityService;
+
+  /**
+   * コンストラクタ
+   * @param documentPreprocessor 文書前処理サービス
+   * @param bm25SimilarityService BM25 類似度計算サービス
+   */
+  constructor(
+    documentPreprocessor: DocumentPreprocessor = new DocumentPreprocessor(),
+    bm25SimilarityService: Bm25SimilarityService = new Bm25SimilarityService()
+  ) {
+    super(documentPreprocessor);
+    this.bm25SimilarityService = bm25SimilarityService;
+  }
+
+  /**
+   * 単一コレクションの学習を実行する
+   * @param documents 学習対象の文書配列
+   * @param context 学習コンテキスト
+   * @returns 類似度データ
+   */
+  public async train(
+    documents: Document[],
+    context: RecommenderTrainingContext
+  ): Promise<Record<string, SimilarDocument[]>> {
+    this.logTotalDocuments(documents, context);
+
+    const processedDocuments = await this.preprocessDocuments(documents, context);
+    return this.bm25SimilarityService.calculate(processedDocuments, context.options);
+  }
+
+  /**
+   * 双方向学習を実行する
+   * @param documents メインの文書配列
+   * @param targetDocuments ターゲット文書配列
+   * @param context 学習コンテキスト
+   * @returns 類似度データ
+   */
+  public async trainBidirectional(
+    documents: Document[],
+    targetDocuments: Document[],
+    context: RecommenderTrainingContext
+  ): Promise<Record<string, SimilarDocument[]>> {
+    this.logTotalDocuments(documents, context);
+
+    const { processedDocuments, targetProcessedDocuments } = await this.preprocessBidirectionalDocuments(
+      documents,
+      targetDocuments,
+      context
+    );
+
+    return this.bm25SimilarityService.calculateBetweenCollections(
+      processedDocuments,
+      targetProcessedDocuments,
+      context.options
+    );
+  }
+}

--- a/src/lib/strategies/LsaTrainingStrategy.ts
+++ b/src/lib/strategies/LsaTrainingStrategy.ts
@@ -1,0 +1,47 @@
+import { ProcessedDocument } from '../../types/index.js';
+import { DocumentVector } from '../services/SimilarityCalculator.js';
+import { AbstractVectorTrainingStrategy } from './AbstractVectorTrainingStrategy.js';
+import {
+  RecommenderTrainingContext,
+  RecommenderTrainingStrategyMetadata,
+} from './RecommenderTrainingStrategy.js';
+
+/** LSA 学習戦略メタデータ */
+export const lsaTrainingStrategyMetadata: RecommenderTrainingStrategyMetadata = {};
+
+/**
+ * LSA 学習戦略
+ */
+export class LsaTrainingStrategy extends AbstractVectorTrainingStrategy {
+  /**
+   * 単一コレクション用の文書ベクトルを生成する
+   * @param processedDocuments 前処理済み文書配列
+   * @param context 学習コンテキスト
+   * @returns 文書ベクトル配列
+   */
+  protected createDocumentVectors(
+    processedDocuments: ProcessedDocument[],
+    context: RecommenderTrainingContext
+  ): DocumentVector[] {
+    return this.documentVectorFactory.createLsaWordVectors(processedDocuments, context.options);
+  }
+
+  /**
+   * 双方向学習用の文書ベクトルを生成する
+   * @param processedDocuments メイン文書配列
+   * @param targetProcessedDocuments ターゲット文書配列
+   * @param context 学習コンテキスト
+   * @returns 文書ベクトル配列
+   */
+  protected createBidirectionalDocumentVectors(
+    processedDocuments: ProcessedDocument[],
+    targetProcessedDocuments: ProcessedDocument[],
+    context: RecommenderTrainingContext
+  ): { documentVectors: DocumentVector[]; targetDocumentVectors: DocumentVector[] } {
+    return this.documentVectorFactory.createBidirectionalLsaWordVectors(
+      processedDocuments,
+      targetProcessedDocuments,
+      context.options
+    );
+  }
+}

--- a/src/lib/strategies/RecommenderTrainingStrategy.ts
+++ b/src/lib/strategies/RecommenderTrainingStrategy.ts
@@ -1,0 +1,53 @@
+import {
+  Document,
+  ProcessingPipeline,
+  RecommenderOptions,
+  SimilarDocument,
+  TokenFilterOptions,
+} from '../../types/index.js';
+
+/**
+ * 学習戦略の実行コンテキスト
+ */
+export interface RecommenderTrainingContext {
+  /** 推薦設定 */
+  options: RecommenderOptions;
+  /** 処理パイプライン */
+  pipeline: ProcessingPipeline;
+}
+
+/**
+ * 学習戦略に紐づくメタデータ
+ */
+export interface RecommenderTrainingStrategyMetadata {
+  /** アルゴリズム固有のオプション既定値 */
+  optionDefaults?: Partial<RecommenderOptions>;
+  /** アルゴリズム固有のトークンフィルター既定値 */
+  tokenFilterOptionsDefaults?: TokenFilterOptions;
+}
+
+/**
+ * 推薦学習戦略インターフェース
+ */
+export interface RecommenderTrainingStrategy {
+  /**
+   * 単一コレクションの学習を実行する
+   * @param documents 学習対象の文書配列
+   * @param context 学習コンテキスト
+   * @returns 類似度データ
+   */
+  train(documents: Document[], context: RecommenderTrainingContext): Promise<Record<string, SimilarDocument[]>>;
+
+  /**
+   * 双方向学習を実行する
+   * @param documents メインの文書配列
+   * @param targetDocuments ターゲット文書配列
+   * @param context 学習コンテキスト
+   * @returns 類似度データ
+   */
+  trainBidirectional(
+    documents: Document[],
+    targetDocuments: Document[],
+    context: RecommenderTrainingContext
+  ): Promise<Record<string, SimilarDocument[]>>;
+}

--- a/src/lib/strategies/TfidfTrainingStrategy.ts
+++ b/src/lib/strategies/TfidfTrainingStrategy.ts
@@ -1,0 +1,47 @@
+import { ProcessedDocument } from '../../types/index.js';
+import { DocumentVector } from '../services/SimilarityCalculator.js';
+import { AbstractVectorTrainingStrategy } from './AbstractVectorTrainingStrategy.js';
+import {
+  RecommenderTrainingContext,
+  RecommenderTrainingStrategyMetadata,
+} from './RecommenderTrainingStrategy.js';
+
+/** TF-IDF 学習戦略メタデータ */
+export const tfidfTrainingStrategyMetadata: RecommenderTrainingStrategyMetadata = {};
+
+/**
+ * TF-IDF 学習戦略
+ */
+export class TfidfTrainingStrategy extends AbstractVectorTrainingStrategy {
+  /**
+   * 単一コレクション用の文書ベクトルを生成する
+   * @param processedDocuments 前処理済み文書配列
+   * @param context 学習コンテキスト
+   * @returns 文書ベクトル配列
+   */
+  protected createDocumentVectors(
+    processedDocuments: ProcessedDocument[],
+    context: RecommenderTrainingContext
+  ): DocumentVector[] {
+    return this.documentVectorFactory.createTfIdfWordVectors(processedDocuments, context.options);
+  }
+
+  /**
+   * 双方向学習用の文書ベクトルを生成する
+   * @param processedDocuments メイン文書配列
+   * @param targetProcessedDocuments ターゲット文書配列
+   * @param context 学習コンテキスト
+   * @returns 文書ベクトル配列
+   */
+  protected createBidirectionalDocumentVectors(
+    processedDocuments: ProcessedDocument[],
+    targetProcessedDocuments: ProcessedDocument[],
+    context: RecommenderTrainingContext
+  ): { documentVectors: DocumentVector[]; targetDocumentVectors: DocumentVector[] } {
+    return this.documentVectorFactory.createBidirectionalTfIdfWordVectors(
+      processedDocuments,
+      targetProcessedDocuments,
+      context.options
+    );
+  }
+}

--- a/src/lib/tokenizers/JapaneseTokenizer.ts
+++ b/src/lib/tokenizers/JapaneseTokenizer.ts
@@ -16,28 +16,10 @@ export class JapaneseTokenizer implements ITokenizer {
    * @returns トークン配列のPromise
    */
   public async tokenize(text: string): Promise<string[]> {
-    if (!this.kuromojiTokenizer) {
-      await this._initializeKuromojiTokenizer();
-    }
+    const kuromojiTokens = await this.getDetailedTokens(text);
 
-    if (!this.kuromojiTokenizer) {
-      throw new Error('Failed to initialize kuromoji tokenizer');
-    }
-
-    // HTMLタグの除去
-    const cleanText = striptags(text, [], ' ').trim();
-
-    // 空文字列の場合は空配列を返す
-    if (!cleanText) {
-      return [];
-    }
-
-    // 形態素解析を実行
-    const tokens = this.kuromojiTokenizer.tokenize(cleanText);
-
-    // トークン情報を文字列として返す
-    return tokens.map(token => {
-      // 基本形が'*'の場合は表層形を使用
+    // 基本形が'*'の場合は表層形を使用
+    return kuromojiTokens.map((token) => {
       const baseForm = token.basic_form;
       return (baseForm && baseForm !== '*') ? baseForm : token.surface_form;
     });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,8 @@
 export interface Document {
   /** 文書の一意識別子 */
   id: string;
+  /** 文書のタイトル */
+  title?: string;
   /** 文書の内容 */
   content: string;
   /** その他の任意プロパティ */
@@ -17,7 +19,7 @@ export interface Document {
 /**
  * 推薦アルゴリズムの種別
  */
-export type RecommenderAlgorithm = 'tfidf' | 'lsa';
+export type RecommenderAlgorithm = 'tfidf' | 'lsa' | 'bm25';
 
 /**
  * ContentBasedRecommenderの設定オプション
@@ -85,6 +87,8 @@ export interface ProcessedDocument {
   id: string;
   /** トークン化された単語の配列 */
   tokens: string[];
+  /** トークン化されたタイトルの配列 */
+  titleTokens?: string[];
   /** 元の文書データ */
   originalDocument: Document;
 }

--- a/test/BM25Recommender.ts
+++ b/test/BM25Recommender.ts
@@ -1,0 +1,171 @@
+import { expect } from 'chai';
+import ContentBasedRecommender from '../src/lib/ContentBasedRecommender.js';
+import { Document } from '../src/types/index.js';
+
+describe('BM25Recommender', () => {
+  it('should train English documents with BM25 and rank related content first', async () => {
+    const recommender = new ContentBasedRecommender({
+      algorithm: 'bm25',
+      language: 'en',
+      minScore: 0,
+    });
+
+    const documents: Document[] = [
+      {
+        id: '1',
+        title: 'Frontend component design patterns',
+        content: 'javascript frontend component design patterns'
+      },
+      {
+        id: '2',
+        title: 'Component design tutorial',
+        content: 'javascript frontend tutorial for component design'
+      },
+      {
+        id: '3',
+        title: 'Quantum physics',
+        content: 'quantum physics particle experiment results'
+      },
+      {
+        id: '4',
+        title: 'Web component architecture',
+        content: 'web component architecture with javascript frontend'
+      },
+    ];
+
+    await recommender.train(documents);
+
+    const similarDocuments = recommender.getSimilarDocuments('1');
+
+    expect(similarDocuments).to.have.length.greaterThan(0);
+    expect(similarDocuments[0].id).to.equal('2');
+    expect(similarDocuments[0].score).to.be.a('number');
+  });
+
+  it('should index title content for BM25 when title is available', async () => {
+    const recommender = new ContentBasedRecommender({
+      algorithm: 'bm25',
+      language: 'en',
+      minScore: 0,
+    });
+
+    const documents: Document[] = [
+      {
+        id: '1',
+        title: 'Frontend architecture patterns',
+        content: 'delivery planning and team process notes'
+      },
+      {
+        id: '2',
+        title: 'Frontend architecture guide',
+        content: 'roadmap sync and delivery checklist'
+      },
+      {
+        id: '3',
+        title: 'Database query tuning',
+        content: 'index maintenance and vacuum strategy'
+      },
+    ];
+
+    await recommender.train(documents);
+
+    const similarDocuments = recommender.getSimilarDocuments('1');
+
+    expect(similarDocuments).to.have.length.greaterThan(0);
+    expect(similarDocuments[0].id).to.equal('2');
+  });
+
+  it('should respect maxSimilarDocuments with BM25', async () => {
+    const recommender = new ContentBasedRecommender({
+      algorithm: 'bm25',
+      language: 'en',
+      maxSimilarDocuments: 1,
+      minScore: 0,
+    });
+
+    const documents: Document[] = [
+      { id: '1', content: 'machine learning project planning and metrics' },
+      { id: '2', content: 'machine learning evaluation metrics and baselines' },
+      { id: '3', content: 'model deployment planning for machine learning teams' },
+    ];
+
+    await recommender.train(documents);
+
+    expect(recommender.getSimilarDocuments('1')).to.have.length.at.most(1);
+  });
+
+  it('should train mixed Japanese and English documents with BM25', async () => {
+    const recommender = new ContentBasedRecommender({
+      algorithm: 'bm25',
+      language: 'ja',
+      minScore: 0,
+    });
+
+    const documents: Document[] = [
+      { id: '1', content: '機械学習 machine learning の基礎を学ぶ' },
+      { id: '2', content: 'machine learning project planning とモデル評価' },
+      { id: '3', content: '旅行ガイドとホテル予約のコツ' },
+    ];
+
+    await recommender.train(documents);
+
+    const similarDocuments = recommender.getSimilarDocuments('1');
+    const similarIds = similarDocuments.map((document) => document.id);
+
+    expect(similarIds).to.include('2');
+  }).timeout(10000);
+
+  it('should support bidirectional training with BM25', async () => {
+    const recommender = new ContentBasedRecommender({
+      algorithm: 'bm25',
+      language: 'en',
+      minScore: 0,
+    });
+
+    const documents: Document[] = [
+      {
+        id: 'post-1',
+        title: 'Frontend design system',
+        content: 'javascript frontend component design system'
+      },
+      {
+        id: 'post-2',
+        title: 'Database optimization',
+        content: 'database indexing and query optimization guide'
+      },
+    ];
+    const targetDocuments: Document[] = [
+      { id: 'tag-frontend', content: 'frontend javascript component ui' },
+      { id: 'tag-database', content: 'database query performance' },
+    ];
+
+    await recommender.trainBidirectional(documents, targetDocuments);
+
+    const similarDocuments = recommender.getSimilarDocuments('post-1');
+    expect(similarDocuments).to.have.length.greaterThan(0);
+    expect(similarDocuments[0].id).to.equal('tag-frontend');
+  });
+
+  it('should preserve repeated Japanese tokens for BM25 scoring by default', async () => {
+    const recommender = new ContentBasedRecommender({
+      algorithm: 'bm25',
+      language: 'ja',
+      minScore: 0,
+    });
+
+    const documents: Document[] = [
+      { id: '1', content: '猫 猫 猫 犬' },
+      { id: '2', content: '猫 猫' },
+      { id: '3', content: '猫' },
+      { id: '4', content: '車' },
+    ];
+
+    await recommender.train(documents);
+
+    const similarDocuments = recommender.getSimilarDocuments('1');
+
+    expect(similarDocuments[0].id).to.equal('2');
+    expect(similarDocuments[1].id).to.equal('3');
+    expect(similarDocuments[0].score).to.be.greaterThan(similarDocuments[1].score);
+  }).timeout(10000);
+});

--- a/test/ContentBasedRecommender.ts
+++ b/test/ContentBasedRecommender.ts
@@ -46,13 +46,20 @@ describe('ContentBasedRecommender', () => {
       }).to.throw('The option minScore should be a number between 0 and 1');
     });
 
-    it('should only accept algorithm as tfidf or lsa', () => {
+    it('should only accept algorithm as tfidf, lsa or bm25', () => {
       expect(() => {
         const recommender = new ContentBasedRecommender({
-          algorithm: 'bm25' as any,
+          algorithm: 'bm25',
         });
         recommender.train(sampleDocuments);
-      }).to.throw('The option algorithm should be either "tfidf" or "lsa"');
+      }).to.not.throw();
+
+      expect(() => {
+        const recommender = new ContentBasedRecommender({
+          algorithm: 'invalid' as any,
+        });
+        recommender.train(sampleDocuments);
+      }).to.throw('The option algorithm should be either "tfidf", "lsa" or "bm25"');
     });
 
     it('should only accept lsaDimensions greater than 0', () => {

--- a/test/ContentBasedRecommenderImproved.ts
+++ b/test/ContentBasedRecommenderImproved.ts
@@ -52,6 +52,17 @@ describe('ContentBasedRecommender - 改良版', () => {
         });
       }).to.not.throw();
     });
+
+    it('BM25ではremoveDuplicatesの既定値がfalseになること', () => {
+      const recommender = new ContentBasedRecommender({
+        algorithm: 'bm25',
+        language: 'ja'
+      });
+
+      const exportedModel = recommender.export();
+
+      expect(exportedModel.options?.tokenFilterOptions?.removeDuplicates).to.equal(false);
+    });
   });
 
   describe('英語文書の処理', () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -10,6 +10,7 @@ import './factories/ProcessingPipelineFactory.js';
 
 // 統合テスト
 import './ContentBasedRecommenderImproved.js';
+import './BM25Recommender.js';
 import './pipeline-integration-test.js';
 
 // 既存のテスト（後方互換性）


### PR DESCRIPTION
Closes #18

## Summary
- `ContentBasedRecommender` の巨大なモノリシッククラスを責務ごとに分割
- ストラテジーパターンを導入してアルゴリズム切り替えを明確化
- `underscore` への依存をコアロジックから除去
- バグ修正: `EnglishTokenFilter` の `allowedPos` デフォルト値を修正
- Issue #18 対応: BM25 ベース推薦の実装（`Bm25SimilarityService`・`Bm25TrainingStrategy`）

## Main changes

### 新規ファイル

| ファイル | 役割 |
| --- | --- |
| `src/lib/services/RecommenderValidator.ts` | オプション・ドキュメントの入力検証 |
| `src/lib/services/RecommenderOptionsResolver.ts` | デフォルトオプション解決 |
| `src/lib/services/DocumentPreprocessor.ts` | HTMLタグ除去・トークン化・前処理 |
| `src/lib/factories/DocumentVectorFactory.ts` | TF-IDF/LSA ベクトル生成（`services/` から移動） |
| `src/lib/services/SimilarityCalculator.ts` | コサイン類似度計算 |
| `src/lib/services/SimilarityResultBuilder.ts` | 類似度スコアリストの生成・フィルタリング |
| `src/lib/services/Bm25SimilarityService.ts` | BM25 スコア計算（関連: #18） |
| `src/lib/factories/TrainingStrategyFactory.ts` | アルゴリズムに応じたストラテジー選択 |
| `src/lib/strategies/AbstractTrainingStrategy.ts` | ストラテジー基底クラス |
| `src/lib/strategies/AbstractVectorTrainingStrategy.ts` | ベクトル系ストラテジー基底クラス |
| `src/lib/strategies/TfidfTrainingStrategy.ts` | TF-IDF 学習ストラテジー |
| `src/lib/strategies/LsaTrainingStrategy.ts` | LSA 学習ストラテジー |
| `src/lib/strategies/Bm25TrainingStrategy.ts` | BM25 学習ストラテジー（関連: #18） |
| `src/lib/strategies/RecommenderTrainingStrategy.ts` | 学習フロー全体の調整 |
| `test/BM25Recommender.ts` | BM25 推薦テスト（関連: #18） |

### 修正内容
- `ContentBasedRecommender` から上記サービス群へロジックを委譲
- `ProcessingPipelineFactory` を if-else → switch 文に整理
- `JapaneseTokenizer.tokenize()` の重複ロジックを `getDetailedTokens()` に委譲
- `RecommenderValidator`・`ContentBasedRecommender` から `underscore` 依存を除去
  - `_.isArray` → `Array.isArray`
  - `_.isNumber` / `_.isString` → `typeof` ガード
  - `_.has` → `Object.prototype.hasOwnProperty.call`
  - `_.isEqual` → `JSON.stringify` 比較
- `EnglishTokenFilter` の `allowedPos` デフォルト値を `['名詞', '動詞', '形容詞']`（日本語POS誤設定）から `[]` に修正

### Issue #18 対応箇所
- `minisearch` を利用した BM25 インデックス構築・スコア計算（`Bm25SimilarityService`）
- `algorithm: 'bm25'` 指定時に BM25 学習フローを実行（`Bm25TrainingStrategy`）
- `language=en` / `language=ja` 評価データで推薦が実行可能
- `test/BM25Recommender.ts` でテストカバレッジを追加

## Validation
- `npm run tsc`
- `npm run test` (137 tests passing)

## Notes
- 既存の公開 API に変更なし
- `algorithm` を指定しない呼び出し元は従来の TF-IDF 動作を継続
